### PR TITLE
Refactor KSP generator and core schema logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ apidocs:
 .PHONY: clean
 clean:
 	@echo "🧹 Cleaning build artifacts..."
-	@./gradlew clean
+	@./gradlew clean && rm -rf kotlin-js-store
 	@echo "✅ Clean complete!"
 
 .PHONY: lint

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ kover {
             }
             verify {
                 rule {
-                    minBound(25)
+                    minBound(30)
                 }
             }
         }

--- a/buildSrc/src/main/kotlin/kotlin-jvm-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm-convention.gradle.kts
@@ -14,3 +14,7 @@ kotlin {
         optIn.set(listOf("kotlinx.serialization.ExperimentalSerializationApi"))
     }
 }
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,13 +11,18 @@ kotlinxSerialization = "1.9.0"
 kover = "0.9.3"
 ksp = "2.3.2"
 langchain4j = "1.8.0"
+mockk = "1.14.6"
 vanniktechMavenPublish = "0.34.0"
+logging = "7.0.13"
+slf4j = "2.0.17"
 
 [libraries]
+kotlin-logging = { group = "io.github.oshai", name = "kotlin-logging", version.ref = "logging" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 gradle-maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "vanniktechMavenPublish" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 koog-agents-tools = { module = "ai.koog:agents-tools", version.ref = "koog" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-assertions-json = { module = "io.kotest:kotest-assertions-json", version.ref = "kotest" }
@@ -27,6 +32,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 ksp-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 langchain4j-core = { module = "dev.langchain4j:langchain4j-core", version.ref = "langchain4j" }
+slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }

--- a/kotlinx-schema-generator-core/build.gradle.kts
+++ b/kotlinx-schema-generator-core/build.gradle.kts
@@ -10,16 +10,16 @@ dokka {
 }
 
 kotlin {
-
     dependencies {
+        implementation(libs.kotlin.logging)
+        implementation(kotlin("reflect"))
+        runtimeOnly(libs.slf4j.simple)
+
         // test dependencies
         testImplementation(libs.kotlin.test)
         testImplementation(libs.kotest.assertions.core)
         testImplementation(libs.junit.jupiter.params)
         testImplementation(libs.kotest.assertions.json)
+        testImplementation(libs.mockk)
     }
-}
-
-tasks.test {
-    useJUnitPlatform()
 }

--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/AbstractSchemaGenerator.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/AbstractSchemaGenerator.kt
@@ -1,0 +1,30 @@
+package kotlinx.schema.generator.core
+
+import kotlinx.schema.generator.core.ir.SchemaEmitter
+import kotlinx.schema.generator.core.ir.SchemaIntrospector
+
+/**
+ * Abstract base class for generating schemas by combining introspection and representation logic.
+ *
+ * @param T the type of the object for which the schema is being generated
+ * @param R the type of the resulting schema representation
+ * @property introspector the component responsible for introspecting the input and producing a type graph
+ * @property emitter the component responsible for converting the type graph into the desired schema representation
+ */
+public abstract class AbstractSchemaGenerator<T : Any, R : Any>(
+    protected val introspector: SchemaIntrospector<T>,
+    protected val emitter: SchemaEmitter<R>,
+) : SchemaGenerator<T, R> {
+    protected abstract fun getRootName(target: T): String
+
+    override fun generateSchema(target: T): R {
+        val graph = introspector.introspect(target)
+
+        return emitter.emit(graph, getRootName(target))
+    }
+
+    override fun generateSchemaString(target: T): String {
+        val jsonObject = generateSchema(target)
+        return encodeToString(jsonObject)
+    }
+}

--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/SchemaGenerator.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/SchemaGenerator.kt
@@ -1,6 +1,22 @@
 package kotlinx.schema.generator.core
 
-public interface SchemaGenerator<T : Any, R> {
+import kotlin.reflect.KClass
+
+public interface SchemaGenerator<T : Any, R : Any> {
+    /**
+     * Returns the type of the target for which the schema is being generated.
+     *
+     * @return the [KClass] of the target type
+     */
+    public fun targetType(): KClass<T>
+
+    /**
+     * Returns the type of the schema representation being generated.
+     *
+     * @return the [KClass] of the schema representation type
+     */
+    public fun schemaType(): KClass<R>
+
     /**
      * Generates a JSON object representing the schema of the input target.
      *
@@ -16,4 +32,12 @@ public interface SchemaGenerator<T : Any, R> {
      * @return a JSON string representing the schema of the provided object
      */
     public fun generateSchemaString(target: T): String
+
+    /**
+     * Serializes the given schema representation into a string.
+     *
+     * @param schema the schema representation to be serialized
+     * @return a string representing the provided schema
+     */
+    public fun encodeToString(schema: R): String
 }

--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/SchemaGeneratorService.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/SchemaGeneratorService.kt
@@ -1,0 +1,29 @@
+package kotlinx.schema.generator.core
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.ServiceLoader
+import kotlin.reflect.KClass
+
+public object SchemaGeneratorService {
+    private val logger = KotlinLogging.logger {}
+
+    private val serviceLoader = ServiceLoader.load(SchemaGenerator::class.java)
+    private var generators: List<SchemaGenerator<*, *>> = serviceLoader.toList()
+
+    init {
+        logger.info {
+            "Discovered SchemaGenerators: ${serviceLoader.map { it::class.qualifiedName }}"
+        }
+    }
+
+    public fun registeredGenerators(): Collection<SchemaGenerator<*, *>> = generators
+
+    @Suppress("UNCHECKED_CAST")
+    public fun <T : Any, R : Any> getGenerator(
+        targetType: KClass<T>? = null,
+        schemaType: KClass<R>? = null,
+    ): SchemaGenerator<T, R>? =
+        generators
+            .filter { targetType == null || it.targetType() == targetType }
+            .singleOrNull { schemaType == null || it.schemaType() == schemaType } as? SchemaGenerator<T, R>
+}

--- a/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/core/AbstractSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/core/AbstractSchemaGeneratorTest.kt
@@ -1,0 +1,66 @@
+package kotlinx.schema.generator.core
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.schema.generator.core.ir.SchemaEmitter
+import kotlinx.schema.generator.core.ir.SchemaIntrospector
+import kotlinx.schema.generator.core.ir.TypeGraph
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.reflect.KClass
+
+@ExtendWith(MockKExtension::class)
+class AbstractSchemaGeneratorTest {
+    @MockK
+    private lateinit var introspector: SchemaIntrospector<KClass<*>>
+
+    @MockK
+    private lateinit var emitter: SchemaEmitter<Map<String, String>>
+
+    @MockK
+    private lateinit var typeGraph: TypeGraph
+
+    private lateinit var generator: AbstractSchemaGenerator<KClass<*>, Map<String, String>>
+
+    private val rootName = AbstractSchemaGeneratorTest::class.qualifiedName!!
+
+    @BeforeEach
+    fun setUp() {
+        generator =
+            object : AbstractSchemaGenerator<KClass<*>, Map<String, String>>(introspector, emitter) {
+                override fun getRootName(target: KClass<*>): String = target.qualifiedName!!
+
+                override fun targetType(): KClass<KClass<*>> = KClass::class
+
+                override fun schemaType(): KClass<Map<String, String>> =
+                    mapOf<String, String>()::class as KClass<Map<String, String>>
+
+                override fun encodeToString(schema: Map<String, String>): String = "Schema: $schema"
+            }
+    }
+
+    @Test
+    fun generateSchema() {
+        every { introspector.introspect(AbstractSchemaGeneratorTest::class) } returns typeGraph
+        val expectedSchema = mapOf("schema" to "{}")
+        every { emitter.emit(typeGraph, rootName) } returns expectedSchema
+
+        val result = generator.generateSchema(AbstractSchemaGeneratorTest::class)
+
+        result shouldBe expectedSchema
+    }
+
+    @Test
+    fun generateSchemaString() {
+        every { introspector.introspect(AbstractSchemaGeneratorTest::class) } returns typeGraph
+        val expectedSchema = mapOf("schema" to "{}")
+        every { emitter.emit(typeGraph, rootName) } returns expectedSchema
+
+        val result = generator.generateSchemaString(AbstractSchemaGeneratorTest::class)
+
+        result shouldBe "Schema: $expectedSchema"
+    }
+}

--- a/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/core/SchemaGeneratorServiceTest.kt
+++ b/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/core/SchemaGeneratorServiceTest.kt
@@ -1,0 +1,61 @@
+package kotlinx.schema.generator.core
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+
+class SchemaGeneratorServiceTest {
+    class TestGenerator : SchemaGenerator<Int, String> {
+        override fun targetType(): KClass<Int> = Int::class
+
+        override fun schemaType(): KClass<String> = String::class
+
+        override fun generateSchema(target: Int): String {
+            error("Not yet implemented")
+        }
+
+        override fun generateSchemaString(target: Int): String {
+            error("Not yet implemented")
+        }
+
+        override fun encodeToString(schema: String): String {
+            error("Not yet implemented")
+        }
+    }
+
+    @Test
+    fun `Should detect generators`() {
+        val generators = SchemaGeneratorService.registeredGenerators()
+
+        generators.shouldHaveSize(1)
+
+        generators.map { it::class } shouldContain TestGenerator::class
+
+        val generator = generators.single { it::class == TestGenerator::class } as TestGenerator
+        generator.shouldBeInstanceOf<TestGenerator>()
+    }
+
+    @Test
+    fun `Should get generator by type`() {
+        val generator =
+            SchemaGeneratorService
+                .getGenerator(
+                    targetType = Int::class,
+                    schemaType = String::class,
+                )
+        generator.shouldBeInstanceOf<TestGenerator>()
+
+        SchemaGeneratorService
+            .getGenerator<Int, Any>(
+                targetType = Int::class,
+            ) shouldBeSameInstanceAs generator
+
+        SchemaGeneratorService
+            .getGenerator<Any, String>(
+                schemaType = String::class,
+            ) shouldBeSameInstanceAs generator
+    }
+}

--- a/kotlinx-schema-generator-core/src/test/resources/META-INF/services/kotlinx.schema.generator.core.SchemaGenerator
+++ b/kotlinx-schema-generator-core/src/test/resources/META-INF/services/kotlinx.schema.generator.core.SchemaGenerator
@@ -1,0 +1,1 @@
+kotlinx.schema.generator.core.SchemaGeneratorServiceTest$TestGenerator

--- a/kotlinx-schema-generator-core/src/test/resources/simplelogger.properties
+++ b/kotlinx-schema-generator-core/src/test/resources/simplelogger.properties
@@ -1,0 +1,7 @@
+# Level of logging for the ROOT logger: ERROR, WARN, INFO, DEBUG, TRACE (default is INFO)
+org.slf4j.simpleLogger.defaultLogLevel=INFO
+org.slf4j.simpleLogger.showThreadName=true
+org.slf4j.simpleLogger.showDateTime=false
+
+# Log level for specific packages or classes
+org.slf4j.simpleLogger.log.kotlinx.schema=DEBUG

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/JsonSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/JsonSchemaGenerator.kt
@@ -22,8 +22,7 @@ public interface JsonSchemaGenerator<T : Any> : SchemaGenerator<T, JsonObject> {
      * @param target the object for which the schema will be generated
      * @return a JSON string representing the schema of the provided object
      */
-    public override fun generateSchemaString(target: T): String =
-        Json.encodeToString(
-            generateSchema(target),
-        )
+    public override fun generateSchemaString(target: T): String = encodeToString(generateSchema(target))
+
+    override fun encodeToString(schema: JsonObject): String = Json.encodeToString(schema)
 }

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/SimpleJsonSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/SimpleJsonSchemaGenerator.kt
@@ -1,7 +1,6 @@
 package kotlinx.schema.generator.json
 
 import kotlinx.schema.generator.json.internal.BasicJsonSchemaGenerator
-import kotlinx.schema.generator.json.internal.StandardJsonSchemaGenerator
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -12,8 +11,12 @@ import kotlin.reflect.KClass
  * A utility class for generating JSON schema representations of Kotlin objects.
  */
 public object SimpleJsonSchemaGenerator : JsonSchemaGenerator<KClass<out Any>> {
-//    private val standardGenerator = StandardJsonSchemaGenerator.Default
+    //    private val standardGenerator = StandardJsonSchemaGenerator.Default
     private val basicGenerator = BasicJsonSchemaGenerator.Default
+
+    override fun targetType(): KClass<KClass<out Any>> = KClass::class
+
+    override fun schemaType(): KClass<JsonObject> = JsonObject::class
 
     @OptIn(InternalSerializationApi::class)
     public override fun generateSchema(target: KClass<out Any>): JsonObject =

--- a/kotlinx-schema-ksp/build.gradle.kts
+++ b/kotlinx-schema-ksp/build.gradle.kts
@@ -10,13 +10,12 @@ dokka {
 }
 
 kotlin {
-
     dependencies {
         implementation(project(":kotlinx-schema-generator-json"))
         implementation(libs.ksp.api)
         // tests
         testImplementation(libs.kotlin.test)
         testImplementation(libs.kotest.assertions.core)
-        testImplementation(kotlin("reflect"))
+        testImplementation(libs.mockk)
     }
 }

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/KspSchemaGenerator.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/KspSchemaGenerator.kt
@@ -1,40 +1,45 @@
 package kotlinx.schema.ksp
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import kotlinx.schema.generator.core.SchemaGenerator
-import kotlinx.schema.generator.core.ir.SchemaEmitter
-import kotlinx.schema.generator.core.ir.SchemaIntrospector
+import kotlinx.schema.generator.core.AbstractSchemaGenerator
 import kotlinx.schema.generator.json.internal.IrStandardJsonSchemaEmitter
 import kotlinx.schema.ksp.ir.KspIntrospector
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlin.reflect.KClass
 
 /**
- * KSP-backed schema generator that uses the generic IR + emitter pipeline.
- * This demonstrates that generators can be generalized to consume abstract metadata
- * (here: KSP symbols) and emit JSON Schema without coupling to KSP or Serialization specifics.
+ * A concrete implementation of [AbstractSchemaGenerator] that generates JSON schema representations
+ * for Kotlin classes using the Kotlin Symbol Processing (KSP) API.
+ *
+ * This object uses [KspIntrospector] to analyze Kotlin classes and produce a type graph, and
+ * [IrStandardJsonSchemaEmitter] to generate a JSON schema representation from the type graph. The schema
+ * is serialized into a JSON string using Kotlinx Serialization.
+ *
+ * This generator is designed to support producing schemas with:
+ * - Pretty-printed JSON
+ * - Default values included in the output
  */
-internal object KspSchemaGenerator : SchemaGenerator<KSClassDeclaration, JsonObject> {
+internal class KspSchemaGenerator :
+    AbstractSchemaGenerator<KSClassDeclaration, JsonObject>(
+        introspector = KspIntrospector(),
+        emitter = IrStandardJsonSchemaEmitter(),
+    ) {
     private val json =
         Json {
             prettyPrint = true
             encodeDefaults = true
         }
 
-    private val introspector: SchemaIntrospector<KSClassDeclaration> = KspIntrospector()
-    private val emitter: SchemaEmitter<JsonObject> = IrStandardJsonSchemaEmitter()
-
-    override fun generateSchema(target: KSClassDeclaration): JsonObject {
+    override fun getRootName(target: KSClassDeclaration): String {
         val className = target.simpleName.asString()
         val packageName = target.packageName.asString()
-        val qualifiedName = target.qualifiedName?.asString() ?: "$packageName.$className"
-
-        val graph = introspector.introspect(target)
-        return emitter.emit(graph, qualifiedName)
+        return target.qualifiedName?.asString() ?: "$packageName.$className"
     }
 
-    override fun generateSchemaString(target: KSClassDeclaration): String {
-        val jsonObject = generateSchema(target)
-        return json.encodeToString(jsonObject)
-    }
+    override fun targetType(): KClass<KSClassDeclaration> = KSClassDeclaration::class
+
+    override fun schemaType(): KClass<JsonObject> = JsonObject::class
+
+    override fun encodeToString(schema: JsonObject): String = json.encodeToString(schema)
 }

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/SchemaExtensionProcessor.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/SchemaExtensionProcessor.kt
@@ -8,7 +8,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.validate
-import kotlinx.schema.generator.core.SchemaGenerator
+import kotlinx.schema.generator.core.SchemaGeneratorService
 
 private const val KOTLINX_SCHEMA_ANNOTATION = "kotlinx.schema.Schema"
 
@@ -25,7 +25,15 @@ internal class SchemaExtensionProcessor(
     private val logger: KSPLogger,
     private val options: Map<String, String>,
 ) : SymbolProcessor {
-    private val schemaGenerator: SchemaGenerator<KSClassDeclaration, out Any> = KspSchemaGenerator
+    private val schemaGenerator = KspSchemaGenerator()
+
+    override fun finish() {
+        logger.info("✅ Done!")
+    }
+
+    override fun onError() {
+        logger.error("💥 Error!")
+    }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val schemaAnnotationName = KOTLINX_SCHEMA_ANNOTATION
@@ -124,10 +132,9 @@ internal class SchemaExtensionProcessor(
 
     private fun getSchemaParameters(classDeclaration: KSClassDeclaration): Map<String, Any?> {
         val schemaAnnotation =
-            classDeclaration.annotations
-                .firstOrNull {
-                    it.shortName.getShortName() == "Schema"
-                }
+            classDeclaration.annotations.firstOrNull {
+                it.shortName.getShortName() == "Schema"
+            }
         if (schemaAnnotation == null) {
             return mapOf()
         }
@@ -136,12 +143,9 @@ internal class SchemaExtensionProcessor(
         val defaultParameters = getSchemaAnnotationDefaults()
 
         val parameters =
-            schemaAnnotation
-                .arguments
-                .filter { it.name != null }
-                .associate {
-                    it.name!!.getShortName() to it.value
-                }
+            schemaAnnotation.arguments.filter { it.name != null }.associate {
+                it.name!!.getShortName() to it.value
+            }
         return defaultParameters.plus(parameters)
     }
 
@@ -224,10 +228,7 @@ internal class SchemaExtensionProcessor(
      * Escapes a string for use as a Kotlin raw string literal, preserving $ and triple quotes.
      */
     private fun String.escapeForKotlinString(): String {
-        val escaped =
-            this
-                .replace("$", "\${'$'}")
-                .replace("\"\"\"", "\\\"\\\"\\\"")
+        val escaped = this.replace("$", "\${'$'}").replace("\"\"\"", "\\\"\\\"\\\"")
         return "\"\"\"" + escaped + "\"\"\""
     }
 }

--- a/kotlinx-schema-ksp/src/main/resources/META-INF/services/kotlinx.schema.generator.core.SchemaGenerator
+++ b/kotlinx-schema-ksp/src/main/resources/META-INF/services/kotlinx.schema.generator.core.SchemaGenerator
@@ -1,0 +1,1 @@
+kotlinx.schema.ksp.KspSchemaGenerator

--- a/kotlinx-schema-ksp/src/test/kotlin/kotlinx/schema/ksp/KspSchemaGeneratorTest.kt
+++ b/kotlinx-schema-ksp/src/test/kotlin/kotlinx/schema/ksp/KspSchemaGeneratorTest.kt
@@ -1,0 +1,20 @@
+package kotlinx.schema.ksp
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import io.kotest.matchers.collections.shouldHaveAtLeastSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import kotlinx.schema.generator.core.SchemaGeneratorService
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class KspSchemaGeneratorTest {
+    @Test
+    fun `Should register KspSchemaGenerator`() {
+        SchemaGeneratorService.registeredGenerators() shouldHaveAtLeastSize 1
+        val generator =
+            SchemaGeneratorService.getGenerator<KSClassDeclaration, Any>(targetType = KSClassDeclaration::class)
+        generator shouldNotBeNull {
+            assertTrue(this is KspSchemaGenerator)
+        }
+    }
+}

--- a/kotlinx-schema-ksp/src/test/kotlin/kotlinx/schema/ksp/SchemaExtensionProcessorProviderTest.kt
+++ b/kotlinx-schema-ksp/src/test/kotlin/kotlinx/schema/ksp/SchemaExtensionProcessorProviderTest.kt
@@ -1,0 +1,39 @@
+package kotlinx.schema.ksp
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class SchemaExtensionProcessorProviderTest {
+    @MockK
+    private lateinit var options: Map<String, String>
+
+    @MockK
+    private lateinit var kspLogger: KSPLogger
+
+    @MockK
+    private lateinit var codeGenerator: CodeGenerator
+
+    @MockK
+    private lateinit var environment: SymbolProcessorEnvironment
+
+    private val provider = SchemaExtensionProcessorProvider()
+
+    @Test
+    fun `Should create generator`() {
+        every { environment.codeGenerator } returns codeGenerator
+        every { environment.logger } returns kspLogger
+        every { environment.options } returns options
+
+        val processor = provider.create(environment = environment)
+
+        processor.shouldBeInstanceOf<SchemaExtensionProcessor>()
+    }
+}


### PR DESCRIPTION
# Refactor KSP generator and core schema logic

- Introduce `SchemaGeneratorService` for dynamic generator discovery and retrieval.
- Add type-safe methods (`targetType`, `schemaType`) to `SchemaGenerator` for improved extensibility.
- Enhance schema parameter handling and serialization consistency.
- Convert `KspSchemaGenerator` to a class and extend `AbstractSchemaGenerator`.
- Integrate `kotlin-logging` and `slf4j-simple` for logging.
- Expand test coverage with MockK-based unit tests (`AbstractSchemaGeneratorTest`, `SchemaGeneratorServiceTest`) and generator registration validation.
- Update build scripts, configurations, and dependencies for reflection, logging, and testing.