### PR TITLE
Add JSON Schema emitter and reflection-based generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ C4Context
 
 
     Rel(kxsGenJson, kxsGenCore, "uses")
+    Rel(kxsGenJson, kxsJsn, "uses")
     Rel(kxsGenCore, kxsAnnotations, "knows")
     Rel(kxsKsp, kxsGenJson, "uses")
     

--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-convention.gradle.kts
@@ -1,3 +1,7 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 plugins {
     kotlin("multiplatform")
 }
@@ -10,7 +14,6 @@ kotlin {
         freeCompilerArgs =
             listOf(
                 "-Wextra",
-                "-Xjvm-default=all",
                 "-Xmulti-dollar-interpolation",
             )
     }
@@ -22,13 +25,6 @@ kotlin {
     explicitApi()
 
     jvm {
-        //    jvmToolchain(17)
-//        compilerOptions {
-//            javaParameters = true
-//            freeCompilerArgs.addAll("-Xdebug")
-//            optIn.set(listOf("kotlinx.serialization.ExperimentalSerializationApi"))
-//        }
-
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
         }
@@ -38,6 +34,7 @@ kotlin {
         browser()
         nodejs()
     }
+
     wasmJs {
         binaries.library()
         browser {}

--- a/kotlinx-schema-generator-core/build.gradle.kts
+++ b/kotlinx-schema-generator-core/build.gradle.kts
@@ -16,10 +16,12 @@ kotlin {
         runtimeOnly(libs.slf4j.simple)
 
         // test dependencies
+        testImplementation(project(":kotlinx-schema-annotations"))
         testImplementation(libs.kotlin.test)
         testImplementation(libs.kotest.assertions.core)
         testImplementation(libs.junit.jupiter.params)
         testImplementation(libs.kotest.assertions.json)
         testImplementation(libs.mockk)
+        testImplementation(libs.kotlinx.serialization.json)
     }
 }

--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospector.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospector.kt
@@ -1,0 +1,336 @@
+package kotlinx.schema.generator.reflect
+
+import kotlinx.schema.generator.core.ir.DefaultPresence
+import kotlinx.schema.generator.core.ir.Discriminator
+import kotlinx.schema.generator.core.ir.EnumNode
+import kotlinx.schema.generator.core.ir.Introspections
+import kotlinx.schema.generator.core.ir.ListNode
+import kotlinx.schema.generator.core.ir.MapNode
+import kotlinx.schema.generator.core.ir.ObjectNode
+import kotlinx.schema.generator.core.ir.PolymorphicNode
+import kotlinx.schema.generator.core.ir.PrimitiveKind
+import kotlinx.schema.generator.core.ir.PrimitiveNode
+import kotlinx.schema.generator.core.ir.Property
+import kotlinx.schema.generator.core.ir.SchemaIntrospector
+import kotlinx.schema.generator.core.ir.SubtypeRef
+import kotlinx.schema.generator.core.ir.TypeGraph
+import kotlinx.schema.generator.core.ir.TypeId
+import kotlinx.schema.generator.core.ir.TypeNode
+import kotlinx.schema.generator.core.ir.TypeRef
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+import kotlin.reflect.KProperty1
+import kotlin.reflect.KType
+
+/**
+ * Introspects Kotlin classes using reflection to build a [TypeGraph].
+ *
+ * This introspector analyzes class structures including properties, constructors,
+ * and type hierarchies to generate schema IR nodes.
+ *
+ *  ## Example
+ *  ```kotlin
+ *  val typeGraph = ReflectionIntrospector.introspect(MyClass::class)
+ *  ```
+ *
+ * ## Limitations
+ * - Requires classes to have a primary constructor
+ * - Type parameters are not fully supported
+ */
+public object ReflectionIntrospector : SchemaIntrospector<KClass<*>> {
+    override fun introspect(root: KClass<*>): TypeGraph {
+        val context = IntrospectionContext()
+        val rootRef = context.convertToTypeRef(root)
+        return TypeGraph(root = rootRef, nodes = context.discoveredNodes)
+    }
+
+    /**
+     * Maintains state during introspection including discovered nodes,
+     * visited classes, and type reference cache.
+     */
+    @Suppress("TooManyFunctions")
+    private class IntrospectionContext {
+        val discoveredNodes = linkedMapOf<TypeId, TypeNode>()
+        private val visitingClasses = mutableSetOf<KClass<*>>()
+        private val typeRefCache = mutableMapOf<KClass<*>, TypeRef>()
+
+        /**
+         * Converts a KClass to a TypeRef, handling caching and nullability.
+         */
+        @Suppress("ReturnCount")
+        fun convertToTypeRef(
+            klass: KClass<*>,
+            nullable: Boolean = false,
+            useSimpleName: Boolean = false,
+        ): TypeRef {
+            // Check cache for non-nullable version, adjust if needed
+            typeRefCache[klass]?.let { cachedRef ->
+                return if (nullable && !cachedRef.nullable) {
+                    cachedRef.withNullable(true)
+                } else {
+                    cachedRef
+                }
+            }
+
+            // Try to convert to primitive type
+            primitiveKindFor(klass)?.let { primitiveKind ->
+                val ref = TypeRef.Inline(PrimitiveNode(primitiveKind), nullable)
+                if (!nullable) typeRefCache[klass] = ref
+                return ref
+            }
+
+            // Handle different type categories
+            return when {
+                isListLike(klass) -> handleListType(klass, nullable)
+                klass == Map::class -> handleMapType(klass, nullable)
+                isEnumClass(klass) -> handleEnumType(klass, nullable)
+                klass.isSealed -> handleSealedType(klass, nullable)
+                else -> handleObjectType(klass, nullable, useSimpleName)
+            }
+        }
+
+        /**
+         * Converts a KType (with type arguments) to a TypeRef.
+         * Used for property types where we have full type information.
+         */
+        private fun convertKTypeToTypeRef(type: KType): TypeRef {
+            val classifier =
+                requireNotNull(type.classifier as? KClass<*>) {
+                    "Unsupported classifier: ${type.classifier}. " +
+                        "Only KClass classifiers are supported. Type parameters and other classifiers " +
+                        "cannot be introspected using reflection."
+                }
+            val isNullable = type.isMarkedNullable
+
+            return when {
+                isListLike(classifier) -> {
+                    val elementType = type.arguments.firstOrNull()?.type
+                    val elementRef =
+                        elementType?.let { convertKTypeToTypeRef(it) }
+                            ?: TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING), false)
+                    TypeRef.Inline(ListNode(elementRef), isNullable)
+                }
+
+                classifier == Map::class -> {
+                    val keyType = type.arguments.getOrNull(0)?.type
+                    val valueType = type.arguments.getOrNull(1)?.type
+                    val keyRef =
+                        keyType?.let { convertKTypeToTypeRef(it) }
+                            ?: TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING), false)
+                    val valueRef =
+                        valueType?.let { convertKTypeToTypeRef(it) }
+                            ?: TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING), false)
+                    TypeRef.Inline(MapNode(keyRef, valueRef), isNullable)
+                }
+
+                else -> convertToTypeRef(classifier, isNullable)
+            }
+        }
+
+        private fun handleListType(
+            klass: KClass<*>,
+            nullable: Boolean,
+        ): TypeRef {
+            // Fallback for when we don't have type arguments (shouldn't happen in normal usage)
+            val elementRef = TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING), false)
+            val ref = TypeRef.Inline(ListNode(elementRef), nullable)
+            if (!nullable) typeRefCache[klass] = ref
+            return ref
+        }
+
+        private fun handleMapType(
+            klass: KClass<*>,
+            nullable: Boolean,
+        ): TypeRef {
+            // Fallback for when we don't have type arguments
+            val keyRef = TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING), false)
+            val valueRef = TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING), false)
+            val ref = TypeRef.Inline(MapNode(keyRef, valueRef), nullable)
+            if (!nullable) typeRefCache[klass] = ref
+            return ref
+        }
+
+        private fun handleEnumType(
+            klass: KClass<*>,
+            nullable: Boolean,
+        ): TypeRef {
+            val id = createTypeId(klass)
+
+            if (shouldProcessClass(klass, id)) {
+                markAsVisiting(klass)
+                val enumNode = createEnumNode(klass)
+                discoveredNodes[id] = enumNode
+                unmarkAsVisiting(klass)
+            }
+
+            val ref = TypeRef.Ref(id, nullable)
+            if (!nullable) typeRefCache[klass] = ref
+            return ref
+        }
+
+        private fun handleSealedType(
+            klass: KClass<*>,
+            nullable: Boolean,
+        ): TypeRef {
+            val id = createTypeId(klass)
+
+            if (shouldProcessClass(klass, id)) {
+                markAsVisiting(klass)
+                val polymorphicNode = createPolymorphicNode(klass)
+                discoveredNodes[id] = polymorphicNode
+
+                // Process each sealed subclass
+                klass.sealedSubclasses.forEach { subclass ->
+                    convertToTypeRef(subclass, nullable = false, useSimpleName = true)
+                }
+
+                unmarkAsVisiting(klass)
+            }
+
+            val ref = TypeRef.Ref(id, nullable)
+            if (!nullable) typeRefCache[klass] = ref
+            return ref
+        }
+
+        private fun handleObjectType(
+            klass: KClass<*>,
+            nullable: Boolean,
+            useSimpleName: Boolean,
+        ): TypeRef {
+            val id =
+                if (useSimpleName) {
+                    TypeId(klass.simpleName ?: "Unknown")
+                } else {
+                    createTypeId(klass)
+                }
+
+            if (shouldProcessClass(klass, id)) {
+                markAsVisiting(klass)
+                val objectNode = createObjectNode(klass)
+                discoveredNodes[id] = objectNode
+                unmarkAsVisiting(klass)
+            }
+
+            val ref = TypeRef.Ref(id, nullable)
+            if (!nullable) typeRefCache[klass] = ref
+            return ref
+        }
+
+        private fun createEnumNode(klass: KClass<*>): EnumNode {
+            @Suppress("UNCHECKED_CAST")
+            val enumConstants = (klass.java as Class<out Enum<*>>).enumConstants
+            return EnumNode(
+                name = klass.simpleName ?: "UnknownEnum",
+                entries = enumConstants.map { it.name },
+                description = extractDescription(klass.annotations),
+            )
+        }
+
+        private fun createPolymorphicNode(klass: KClass<*>): PolymorphicNode {
+            val subtypes =
+                klass.sealedSubclasses.map { subclass ->
+                    SubtypeRef(TypeId(subclass.simpleName ?: "Unknown"))
+                }
+            return PolymorphicNode(
+                baseName = klass.simpleName ?: "UnknownSealed",
+                subtypes = subtypes,
+                discriminator = Discriminator(name = "type", required = true, mapping = null),
+                description = extractDescription(klass.annotations),
+            )
+        }
+
+        private fun createObjectNode(klass: KClass<*>): ObjectNode {
+            val properties = mutableListOf<Property>()
+            val requiredProperties = mutableSetOf<String>()
+
+            // Extract properties from primary constructor
+            klass.constructors.firstOrNull()?.parameters?.forEach { param ->
+                val propertyName = param.name ?: return@forEach
+                val hasDefault = param.isOptional
+
+                // Find the corresponding property to get annotations
+                val property =
+                    klass.members
+                        .filterIsInstance<KProperty<*>>()
+                        .firstOrNull { it.name == propertyName }
+
+                val propertyType = param.type
+                val typeRef = convertKTypeToTypeRef(propertyType)
+
+                properties +=
+                    Property(
+                        name = propertyName,
+                        type = typeRef,
+                        description = property?.let { extractDescription(it.annotations) },
+                        defaultPresence = if (hasDefault) DefaultPresence.Absent else DefaultPresence.Required,
+                    )
+
+                if (!hasDefault) {
+                    requiredProperties += propertyName
+                }
+            }
+
+            return ObjectNode(
+                name = klass.simpleName ?: "UnknownClass",
+                properties = properties,
+                required = requiredProperties,
+                description = extractDescription(klass.annotations),
+            )
+        }
+
+        private fun shouldProcessClass(
+            klass: KClass<*>,
+            id: TypeId,
+        ): Boolean = id !in discoveredNodes.keys && klass !in visitingClasses
+
+        private fun markAsVisiting(klass: KClass<*>) {
+            visitingClasses += klass
+        }
+
+        private fun unmarkAsVisiting(klass: KClass<*>) {
+            visitingClasses -= klass
+        }
+
+        private fun createTypeId(klass: KClass<*>): TypeId =
+            TypeId(klass.qualifiedName ?: klass.simpleName ?: "Anonymous")
+
+        private fun isListLike(klass: KClass<*>): Boolean =
+            klass == List::class || klass == Collection::class || klass == Iterable::class
+
+        private fun isEnumClass(klass: KClass<*>): Boolean = klass.isData == false && klass.java.isEnum
+
+        private fun primitiveKindFor(klass: KClass<*>): PrimitiveKind? =
+            when (klass) {
+                String::class -> PrimitiveKind.STRING
+                Boolean::class -> PrimitiveKind.BOOLEAN
+                Byte::class, Short::class, Int::class -> PrimitiveKind.INT
+                Long::class -> PrimitiveKind.LONG
+                Float::class -> PrimitiveKind.FLOAT
+                Double::class -> PrimitiveKind.DOUBLE
+                Char::class -> PrimitiveKind.STRING
+                else -> null
+            }
+
+        private fun extractDescription(annotations: List<Annotation>): String? =
+            annotations.firstNotNullOfOrNull { annotation ->
+                val annotationName = annotation.annotationClass.simpleName ?: return@firstNotNullOfOrNull null
+                val annotationArguments =
+                    buildList {
+                        runCatching {
+                            annotation.annotationClass.members
+                                .filterIsInstance<KProperty1<Annotation, *>>()
+                                .forEach { property ->
+                                    runCatching { add(property.name to property.get(annotation)) }
+                                }
+                        }
+                    }
+                Introspections.getDescriptionFromAnnotation(annotationName, annotationArguments)
+            }
+
+        private fun TypeRef.withNullable(nullable: Boolean): TypeRef =
+            when (this) {
+                is TypeRef.Inline -> copy(nullable = nullable)
+                is TypeRef.Ref -> copy(nullable = nullable)
+            }
+    }
+}

--- a/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectorTest.kt
+++ b/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectorTest.kt
@@ -1,0 +1,193 @@
+package kotlinx.schema.generator.reflect
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.schema.Description
+import kotlinx.schema.generator.core.ir.DefaultPresence
+import kotlinx.schema.generator.core.ir.EnumNode
+import kotlinx.schema.generator.core.ir.ListNode
+import kotlinx.schema.generator.core.ir.MapNode
+import kotlinx.schema.generator.core.ir.ObjectNode
+import kotlinx.schema.generator.core.ir.PolymorphicNode
+import kotlinx.schema.generator.core.ir.PrimitiveKind
+import kotlinx.schema.generator.core.ir.PrimitiveNode
+import kotlinx.schema.generator.core.ir.TypeId
+import kotlinx.schema.generator.core.ir.TypeRef
+import kotlin.test.Test
+
+class ReflectionIntrospectorTest {
+    @Description("A user model")
+    data class User(
+        @property:Description("The name of the user")
+        val name: String,
+        val age: Int?,
+        val email: String = "n/a",
+        val tags: List<String>,
+        val attributes: Map<String, Int>?,
+    )
+
+    @Description("Available colors")
+    enum class Color { RED, GREEN, BLUE }
+
+    data class WithEnum(
+        val color: Color,
+    )
+
+    sealed class Shape {
+        @Description("Circle shape")
+        data class Circle(
+            val radius: Double,
+        ) : Shape()
+
+        @Description("Rectangle shape")
+        data class Rectangle(
+            val width: Double,
+            val height: Double,
+        ) : Shape()
+    }
+
+    private val introspector = ReflectionIntrospector
+
+    @Test
+    @Suppress("LongMethod")
+    fun `introspects object with primitives list map nullability and defaults`() {
+        val graph = introspector.introspect(User::class)
+
+        // Root must be a ref to the User id (serial name)
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        rootRef.id.value shouldBe User::class.qualifiedName
+        rootRef.nullable shouldBe false
+
+        val userNode = graph.nodes[rootRef.id].shouldBeInstanceOf<ObjectNode>()
+
+        // Verify class-level description
+        userNode.description shouldBe "A user model"
+
+        // Required should include all without defaults: name, age, tags, attributes (email has default)
+        userNode.required.shouldContainExactlyInAnyOrder(setOf("name", "age", "tags", "attributes"))
+
+        // Properties: check types
+        val props = userNode.properties.associateBy { it.name }
+
+        // Verify property with description and required status
+        props.getValue("name").apply {
+            description shouldBe "The name of the user"
+            defaultPresence shouldBe DefaultPresence.Required
+            type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+                inline.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
+                    prim.kind shouldBe PrimitiveKind.STRING
+                }
+                inline.nullable shouldBe false
+            }
+        }
+
+        // age is nullable but still required (no default value)
+        props.getValue("age").apply {
+            defaultPresence shouldBe DefaultPresence.Required
+            type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+                inline.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
+                    prim.kind shouldBe PrimitiveKind.INT
+                }
+                inline.nullable shouldBe true
+            }
+        }
+
+        // email has default value, so defaultPresence should be Absent
+        props.getValue("email").apply {
+            defaultPresence shouldBe DefaultPresence.Absent
+            type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+                inline.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
+                    prim.kind shouldBe PrimitiveKind.STRING
+                }
+            }
+        }
+
+        // tags is required (no default)
+        props.getValue("tags").apply {
+            defaultPresence shouldBe DefaultPresence.Required
+        }
+
+        // attributes is nullable but required (no default)
+        props.getValue("attributes").apply {
+            defaultPresence shouldBe DefaultPresence.Required
+        }
+
+        // Verify collection types
+        props.getValue("tags").type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+            inline.node.shouldBeInstanceOf<ListNode> { list ->
+                list.element.shouldBeInstanceOf<TypeRef.Inline> { el ->
+                    el.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
+                        prim.kind shouldBe PrimitiveKind.STRING
+                    }
+                }
+            }
+        }
+
+        props.getValue("attributes").type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+            inline.nullable shouldBe true
+            inline.node.shouldBeInstanceOf<MapNode> { map ->
+                map.key.shouldBeInstanceOf<TypeRef.Inline> { k ->
+                    k.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
+                        prim.kind shouldBe PrimitiveKind.STRING
+                    }
+                }
+                map.value.shouldBeInstanceOf<TypeRef.Inline> { v ->
+                    v.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
+                        prim.kind shouldBe PrimitiveKind.INT
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `introspects enum and adds node with entries and description`() {
+        val graph = introspector.introspect(WithEnum::class)
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val withEnumNode = graph.nodes[rootRef.id].shouldBeInstanceOf<ObjectNode>()
+        val colorProp = withEnumNode.properties.first { it.name == "color" }
+
+        val colorRef = colorProp.type.shouldBeInstanceOf<TypeRef.Ref>()
+        val enumNode = graph.nodes[colorRef.id].shouldBeInstanceOf<EnumNode>()
+
+        // Verify enum entries and description
+        enumNode.entries.shouldContainExactlyInAnyOrder(listOf("RED", "GREEN", "BLUE"))
+        enumNode.description shouldBe "Available colors"
+    }
+
+    @Test
+    fun `introspects sealed polymorphic adds polymorphic node and subtype objects`() {
+        val graph = introspector.introspect(Shape::class)
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val polyNode = graph.nodes[rootRef.id].shouldNotBeNull().shouldBeInstanceOf<PolymorphicNode>()
+
+        // Verify polymorphic node has no description (Shape class is not annotated)
+        polyNode.description shouldBe null
+
+        // Discriminator should be required
+        polyNode.discriminator shouldNotBeNull {
+            name shouldBe "type"
+            required shouldBe true
+        }
+
+        // Ensure subtypes discovered and object nodes present
+        val subtypeIds = polyNode.subtypes.map { it.id.value }.toSet()
+        subtypeIds.shouldContainExactlyInAnyOrder(
+            setOf(
+                Shape.Circle::class.simpleName,
+                Shape.Rectangle::class.simpleName,
+            ),
+        )
+
+        // Verify each subtype has correct description
+        val circleNode = graph.nodes[TypeId("Circle")].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
+        circleNode.description shouldBe "Circle shape"
+
+        val rectangleNode = graph.nodes[TypeId("Rectangle")].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
+        rectangleNode.description shouldBe "Rectangle shape"
+    }
+}

--- a/kotlinx-schema-generator-json/build.gradle.kts
+++ b/kotlinx-schema-generator-json/build.gradle.kts
@@ -14,9 +14,10 @@ kotlin {
 
     dependencies {
         // production dependencies
+        api(libs.kotlinx.serialization.json)
         api(project(":kotlinx-schema-annotations"))
         api(project(":kotlinx-schema-generator-core"))
-        api(libs.kotlinx.serialization.json)
+        api(project(":kotlinx-schema-json"))
 
         // test dependencies
         testImplementation(libs.kotlin.test)

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/JsonSchemaEmitter.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/JsonSchemaEmitter.kt
@@ -1,0 +1,350 @@
+package kotlinx.schema.generator.json
+
+import kotlinx.schema.generator.core.ir.DefaultPresence
+import kotlinx.schema.generator.core.ir.EnumNode
+import kotlinx.schema.generator.core.ir.ListNode
+import kotlinx.schema.generator.core.ir.MapNode
+import kotlinx.schema.generator.core.ir.ObjectNode
+import kotlinx.schema.generator.core.ir.PrimitiveKind
+import kotlinx.schema.generator.core.ir.PrimitiveNode
+import kotlinx.schema.generator.core.ir.SchemaEmitter
+import kotlinx.schema.generator.core.ir.TypeGraph
+import kotlinx.schema.generator.core.ir.TypeNode
+import kotlinx.schema.generator.core.ir.TypeRef
+import kotlinx.schema.json.ArrayPropertyDefinition
+import kotlinx.schema.json.BooleanPropertyDefinition
+import kotlinx.schema.json.JsonSchema
+import kotlinx.schema.json.JsonSchemaDefinition
+import kotlinx.schema.json.NumericPropertyDefinition
+import kotlinx.schema.json.ObjectPropertyDefinition
+import kotlinx.schema.json.PropertyDefinition
+import kotlinx.schema.json.StringPropertyDefinition
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
+
+public data class JsonSchemaConfig(
+    /**
+     * Controls how optional nullable properties are represented in JSON Schema.
+     *
+     * When `true`: `val age: Int? = null` becomes:
+     *   - Included in "required" array
+     *   - Type is `["integer", "null"]`
+     *   - `"default": null` is set
+     *
+     * When false (default): Such properties are omitted from "required"
+     */
+    val treatNullableOptionalAsRequired: Boolean = false,
+    val json: Json = Json,
+) {
+    public companion object {
+        public val DEFAULT: JsonSchemaConfig = JsonSchemaConfig()
+    }
+}
+
+@Suppress("TooManyFunctions")
+public class JsonSchemaEmitter
+    @JvmOverloads
+    public constructor(
+        public val config: JsonSchemaConfig = JsonSchemaConfig.DEFAULT,
+        private val json: Json = Json { encodeDefaults = false },
+    ) : SchemaEmitter<JsonSchema> {
+        override fun emit(
+            graph: TypeGraph,
+            rootName: String,
+        ): JsonSchema {
+            val rootDefinition = convertTypeRef(graph.root, graph)
+
+            // Extract the main schema definition
+            val schemaDefinition =
+                when (rootDefinition) {
+                    is ObjectPropertyDefinition -> {
+                        JsonSchemaDefinition(
+                            properties = rootDefinition.properties ?: emptyMap(),
+                            required = rootDefinition.required ?: emptyList(),
+                            additionalProperties = rootDefinition.additionalProperties,
+                            description = rootDefinition.description,
+                        )
+                    }
+
+                    else -> {
+                        // For non-object types, wrap in a schema definition
+                        JsonSchemaDefinition(
+                            properties = emptyMap(),
+                            required = emptyList(),
+                            additionalProperties = JsonPrimitive(false),
+                        )
+                    }
+                }
+
+            return JsonSchema(
+                name = rootName,
+                strict = false,
+                description = null,
+                schema = schemaDefinition,
+            )
+        }
+
+        private fun convertTypeRef(
+            typeRef: TypeRef,
+            graph: TypeGraph,
+        ): PropertyDefinition =
+            when (typeRef) {
+                is TypeRef.Inline -> convertInlineNode(typeRef.node, typeRef.nullable, graph)
+                is TypeRef.Ref -> {
+                    val node =
+                        graph.nodes[typeRef.id]
+                            ?: throw IllegalStateException(
+                                "Type reference '${typeRef.id.value}' not found in type graph. " +
+                                    "This indicates a bug in the introspector - all referenced types " +
+                                    "should be present in the graph's nodes map.",
+                            )
+                    convertNode(node, typeRef.nullable, graph)
+                }
+            }
+
+        private fun convertInlineNode(
+            node: TypeNode,
+            nullable: Boolean,
+            graph: TypeGraph,
+        ): PropertyDefinition =
+            when (node) {
+                is PrimitiveNode -> convertPrimitive(node, nullable)
+                is ListNode -> convertList(node, nullable, graph)
+                is MapNode -> convertMap(node, nullable, graph)
+                else ->
+                    throw IllegalArgumentException(
+                        "Unsupported inline node type: ${node::class.simpleName}. " +
+                            "Only PrimitiveNode, ListNode, and MapNode can be inlined. " +
+                            "Complex types like ObjectNode and EnumNode must use TypeRef.Ref.",
+                    )
+            }
+
+        private fun convertNode(
+            node: TypeNode,
+            nullable: Boolean,
+            graph: TypeGraph,
+        ): PropertyDefinition =
+            when (node) {
+                is PrimitiveNode -> convertPrimitive(node, nullable)
+                is ObjectNode -> convertObject(node, nullable, graph)
+                is EnumNode -> convertEnum(node, nullable)
+                is ListNode -> convertList(node, nullable, graph)
+                is MapNode -> convertMap(node, nullable, graph)
+                else ->
+                    throw IllegalArgumentException(
+                        "Unsupported node type: ${node::class.simpleName}. " +
+                            "Expected one of: PrimitiveNode, ObjectNode, EnumNode, ListNode, MapNode.",
+                    )
+            }
+
+        private fun convertPrimitive(
+            node: PrimitiveNode,
+            nullable: Boolean,
+        ): PropertyDefinition =
+            when (node.kind) {
+                PrimitiveKind.STRING ->
+                    StringPropertyDefinition(
+                        type = listOf("string"),
+                        description = null,
+                        nullable = if (nullable) true else null,
+                    )
+
+                PrimitiveKind.BOOLEAN ->
+                    BooleanPropertyDefinition(
+                        type = listOf("boolean"),
+                        description = null,
+                        nullable = if (nullable) true else null,
+                    )
+
+                PrimitiveKind.INT ->
+                    NumericPropertyDefinition(
+                        type = listOf("integer"),
+                        description = null,
+                        nullable = if (nullable) true else null,
+                    )
+
+                PrimitiveKind.LONG ->
+                    NumericPropertyDefinition(
+                        type = listOf("integer"),
+                        description = null,
+                        nullable = if (nullable) true else null,
+                    )
+
+                PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE ->
+                    NumericPropertyDefinition(
+                        type = listOf("number"),
+                        description = null,
+                        nullable = if (nullable) true else null,
+                    )
+            }
+
+        private fun convertObject(
+            node: ObjectNode,
+            nullable: Boolean,
+            graph: TypeGraph,
+        ): PropertyDefinition {
+            // Build required list based on config and DefaultPresence
+            val required =
+                if (config.treatNullableOptionalAsRequired) {
+                    // Include all properties in required
+                    node.properties.map { it.name }
+                } else {
+                    // Only include properties without defaults (Required) in required list
+                    node.properties
+                        .filter { property ->
+                            property.defaultPresence == DefaultPresence.Required
+                        }.map { it.name }
+                }.toSet()
+
+            // Convert all properties
+            val properties =
+                node.properties.associate { property ->
+                    val typeRef = property.type
+                    val isNullable =
+                        when (typeRef) {
+                            is TypeRef.Inline -> typeRef.nullable
+                            is TypeRef.Ref -> typeRef.nullable
+                        }
+                    val hasDefault = property.defaultPresence != DefaultPresence.Required
+
+                    val propertyDef = convertTypeRef(property.type, graph)
+
+                    // Adjust based on config and property characteristics
+                    val adjustedDef =
+                        when {
+                            // When treatNullableOptionalAsRequired=true and property has default (is optional):
+                            // add "null" to type array and set default value
+                            config.treatNullableOptionalAsRequired && hasDefault && isNullable -> {
+                                addNullToTypeAndSetDefault(propertyDef)
+                            }
+                            // Property without default (required): remove nullable flag
+                            !hasDefault -> {
+                                removeNullableFlag(propertyDef)
+                            }
+                            // Properties with defaults when config is false: keep as is
+                            else -> propertyDef
+                        }
+
+                    // Add the property description if available
+                    val description = property.description
+                    val finalDef =
+                        if (description != null) {
+                            setDescription(adjustedDef, description)
+                        } else {
+                            adjustedDef
+                        }
+                    property.name to finalDef
+                }
+
+            return ObjectPropertyDefinition(
+                type = listOf("object"),
+                description = node.description,
+                nullable = if (nullable) true else null,
+                properties = properties,
+                required = required.toList(),
+                additionalProperties = JsonPrimitive(false),
+            )
+        }
+
+        private fun addNullToTypeAndSetDefault(propertyDef: PropertyDefinition): PropertyDefinition =
+            when (propertyDef) {
+                is StringPropertyDefinition ->
+                    propertyDef.copy(
+                        type = propertyDef.type + "null",
+                        nullable = null,
+                        default = null,
+                    )
+                is NumericPropertyDefinition ->
+                    propertyDef.copy(
+                        type = propertyDef.type + "null",
+                        nullable = null,
+                        default = null,
+                    )
+                is BooleanPropertyDefinition ->
+                    propertyDef.copy(
+                        type = propertyDef.type + "null",
+                        nullable = null,
+                        default = null,
+                    )
+                is ArrayPropertyDefinition ->
+                    propertyDef.copy(
+                        type = propertyDef.type + "null",
+                        nullable = null,
+                        default = null,
+                    )
+                is ObjectPropertyDefinition ->
+                    propertyDef.copy(
+                        type = propertyDef.type + "null",
+                        nullable = null,
+                        default = null,
+                    )
+                else -> propertyDef
+            }
+
+        private fun removeNullableFlag(propertyDef: PropertyDefinition): PropertyDefinition =
+            when (propertyDef) {
+                is StringPropertyDefinition -> propertyDef.copy(nullable = null)
+                is NumericPropertyDefinition -> propertyDef.copy(nullable = null)
+                is BooleanPropertyDefinition -> propertyDef.copy(nullable = null)
+                is ArrayPropertyDefinition -> propertyDef.copy(nullable = null)
+                is ObjectPropertyDefinition -> propertyDef.copy(nullable = null)
+                else -> propertyDef
+            }
+
+        private fun setDescription(
+            propertyDef: PropertyDefinition,
+            description: String,
+        ): PropertyDefinition =
+            when (propertyDef) {
+                is StringPropertyDefinition -> propertyDef.copy(description = description)
+                is NumericPropertyDefinition -> propertyDef.copy(description = description)
+                is BooleanPropertyDefinition -> propertyDef.copy(description = description)
+                is ArrayPropertyDefinition -> propertyDef.copy(description = description)
+                is ObjectPropertyDefinition -> propertyDef.copy(description = description)
+                else -> propertyDef
+            }
+
+        private fun convertEnum(
+            node: EnumNode,
+            nullable: Boolean,
+        ): PropertyDefinition =
+            StringPropertyDefinition(
+                type = listOf("string"),
+                description = node.description,
+                nullable = if (nullable) true else null,
+                enum = node.entries,
+            )
+
+        private fun convertList(
+            node: ListNode,
+            nullable: Boolean,
+            graph: TypeGraph,
+        ): PropertyDefinition {
+            val items = convertTypeRef(node.element, graph)
+            return ArrayPropertyDefinition(
+                type = listOf("array"),
+                description = null,
+                nullable = if (nullable) true else null,
+                items = items,
+            )
+        }
+
+        private fun convertMap(
+            node: MapNode,
+            nullable: Boolean,
+            graph: TypeGraph,
+        ): PropertyDefinition {
+            // Maps are represented as objects with additionalProperties
+            // The value type determines what additionalProperties accepts
+            val valuePropertyDef = convertTypeRef(node.value, graph)
+            val additionalPropertiesSchema = json.encodeToJsonElement(valuePropertyDef)
+
+            return ObjectPropertyDefinition(
+                type = listOf("object"),
+                description = null,
+                nullable = if (nullable) true else null,
+                additionalProperties = additionalPropertiesSchema,
+            )
+        }
+    }

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/ReflectionJsonSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/ReflectionJsonSchemaGenerator.kt
@@ -1,0 +1,24 @@
+package kotlinx.schema.generator.json
+
+import kotlinx.schema.generator.core.AbstractSchemaGenerator
+import kotlinx.schema.generator.reflect.ReflectionIntrospector
+import kotlinx.schema.json.JsonSchema
+import kotlinx.serialization.json.Json
+import kotlin.reflect.KClass
+
+public class ReflectionJsonSchemaGenerator
+    @JvmOverloads
+    public constructor(
+        jsonSchemaConfig: JsonSchemaConfig = JsonSchemaConfig.DEFAULT,
+    ) : AbstractSchemaGenerator<KClass<out Any>, JsonSchema>(
+            introspector = ReflectionIntrospector,
+            emitter = JsonSchemaEmitter(config = jsonSchemaConfig),
+        ) {
+        override fun getRootName(target: KClass<out Any>): String = target.qualifiedName ?: "Anonymous"
+
+        override fun targetType(): KClass<KClass<out Any>> = KClass::class
+
+        override fun schemaType(): KClass<JsonSchema> = JsonSchema::class
+
+        override fun encodeToString(schema: JsonSchema): String = Json.encodeToString(schema)
+    }

--- a/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/ReflectionJsonSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/ReflectionJsonSchemaGeneratorTest.kt
@@ -1,0 +1,156 @@
+package kotlinx.schema.generator.json
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.schema.Description
+import kotlinx.schema.json.ArrayPropertyDefinition
+import kotlinx.schema.json.NumericPropertyDefinition
+import kotlinx.schema.json.ObjectPropertyDefinition
+import kotlinx.schema.json.StringPropertyDefinition
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+
+class ReflectionJsonSchemaGeneratorTest {
+    @Description("Available colors")
+    enum class Color {
+        RED,
+        GREEN,
+        BLUE,
+    }
+
+    data class WithEnum(
+        @property:Description("The color of the rainbow")
+        val color: Color,
+    )
+
+    private val json =
+        Json {
+            prettyPrint = true
+        }
+
+    // language=json
+
+    @Test
+    fun generateJsonSchema() {
+        @Description("Personal information")
+        data class Person(
+            @property:Description("Person's first name")
+            val firstName: String,
+        )
+
+        val schema =
+            ReflectionJsonSchemaGenerator().generateSchema(Person::class)
+
+        // language=json
+        val expectedSchema = """ 
+        {
+            "name": "${Person::class.qualifiedName}",
+            "strict": false,
+            "schema": {
+              "description": "Personal information",
+              "required": [ "firstName" ],
+              "type": "object",
+              "properties": {
+                "firstName": {
+                  "type": "string",
+                  "description": "Person's first name"
+                }
+              },
+              "additionalProperties": false
+            }
+        }
+        """
+        val actualSchemaString = json.encodeToString(schema)
+        println("Expected schema = $expectedSchema")
+        println("Actual schema = $actualSchemaString")
+    }
+
+    @Test
+    fun generateJsonSchema_forUserWithVariousTypes() {
+        @Description("A user model")
+        data class User(
+            @property:Description("The name of the user")
+            val name: String,
+            val age: Int?,
+            val email: String = "n/a",
+            val tags: List<String>,
+            val attributes: Map<String, Int>?,
+        )
+
+        val schema = ReflectionJsonSchemaGenerator().generateSchema(User::class)
+
+        // language=json
+        val expectedSchema = """
+        {
+            "name": "Anonymous",
+            "strict": false,
+            "schema": {
+              "description": "A user model",
+              "required": [ "name", "age", "tags", "attributes" ],
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The name of the user"
+                },
+                "age": {
+                  "type": "integer"
+                },
+                "email": {
+                  "type": "string"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "attributes": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+        }
+        """
+
+        val actualSchemaString = json.encodeToString(schema)
+
+        actualSchemaString shouldEqualJson expectedSchema
+    }
+
+    @Test
+    fun generateJsonSchema_forEnumProperty() {
+        val schema = ReflectionJsonSchemaGenerator().generateSchema(WithEnum::class)
+
+        // language=json
+        val expectedSchema = """
+        {
+            "name": "${WithEnum::class.qualifiedName}",
+            "strict": false,
+            "schema": {
+              "required": [ "color" ],
+              "type": "object",
+              "properties": {
+                "color": {
+                  "type": "string",
+                  "description": "The color of the rainbow",
+                  "enum": ["RED", "GREEN", "BLUE"]
+                }
+              },
+              "additionalProperties": false
+            }
+        }
+        """
+
+        val actualSchemaString = json.encodeToString(schema)
+
+        actualSchemaString shouldEqualJson expectedSchema
+    }
+}

--- a/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchema.dsl.kt
+++ b/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchema.dsl.kt
@@ -202,6 +202,8 @@ public class JsonSchemaBuilder {
  *
  * ## Example with Multiple Properties
  * ```kotlin
+ * import kotlinx.serialization.json.JsonPrimitive
+ *
  * schema {
  *     additionalProperties = false
  *     property("id") {
@@ -230,13 +232,30 @@ public class JsonSchemaDefinitionBuilder {
      */
     public var schema: String? = null
 
+    private var _additionalProperties: JsonElement? = null
+
     /**
      * Whether additional properties beyond those defined are allowed.
-     * - `true`: Additional properties allowed
-     * - `false`: Only defined properties allowed
+     * - `JsonPrimitive(true)`: Additional properties allowed
+     * - `JsonPrimitive(false)`: Only defined properties allowed
+     * - `JsonObject`: Schema for additional properties (e.g., for maps)
      * - `null`: No constraint (default)
      */
-    public var additionalProperties: Boolean? = null
+    public var additionalProperties: Any?
+        get() = _additionalProperties
+        set(value) {
+            _additionalProperties =
+                when (value) {
+                    is JsonObject -> value
+                    is Boolean -> JsonPrimitive(value)
+                    null -> null
+                    else ->
+                        error(
+                            "additionalProperties  must be Boolean, JsonElement, or null, " +
+                                "but got: ${value::class.simpleName}",
+                        )
+                }
+        }
 
     /**
      * Optional human-readable description.
@@ -289,7 +308,7 @@ public class JsonSchemaDefinitionBuilder {
             schema = schema,
             properties = properties,
             required = requiredFields.toList(),
-            additionalProperties = additionalProperties,
+            additionalProperties = _additionalProperties,
             description = description,
             items = items,
         )
@@ -1194,11 +1213,12 @@ public class ObjectPropertyBuilder internal constructor() {
 
     /**
      * Whether additional properties beyond those defined are allowed.
-     * - `true`: Additional properties allowed
-     * - `false`: Only defined properties allowed
+     * - `JsonPrimitive(true)`: Additional properties allowed
+     * - `JsonPrimitive(false)`: Only defined properties allowed
+     * - `JsonObject`: Schema for additional properties (e.g., for maps)
      * - `null`: No constraint (default)
      */
-    public var additionalProperties: Boolean? = null
+    public var additionalProperties: JsonElement? = null
 
     private val properties: MutableMap<String, PropertyDefinition> = mutableMapOf()
     private val requiredFields: MutableSet<String> = mutableSetOf()

--- a/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchema.kt
+++ b/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchema.kt
@@ -51,7 +51,15 @@ public data class JsonSchemaDefinition(
     public val type: String = "object",
     public val properties: Map<String, PropertyDefinition> = emptyMap(),
     public val required: List<String> = emptyList(),
-    public val additionalProperties: Boolean? = null,
+    /**
+     * Defines whether additional properties are allowed and their schema.
+     * Can be:
+     * - `null`: not specified (defaults to true in JSON Schema)
+     * - `JsonPrimitive(true)`: allow any additional properties
+     * - `JsonPrimitive(false)`: disallow additional properties
+     * - `JsonObject`: a schema defining the type of additional properties (e.g., for Maps)
+     */
+    public val additionalProperties: JsonElement? = null,
     public val description: String? = null,
     public val items: PropertyDefinition? = null,
 )
@@ -160,8 +168,16 @@ public data class ObjectPropertyDefinition(
     override val nullable: Boolean? = null,
     val properties: Map<String, PropertyDefinition>? = null,
     val required: List<String>? = null,
+    /**
+     * Defines whether additional properties are allowed and their schema.
+     * Can be:
+     * - `null`: not specified (defaults to true in JSON Schema)
+     * - `JsonPrimitive(true)`: allow any additional properties
+     * - `JsonPrimitive(false)`: disallow additional properties
+     * - `JsonObject`: a schema defining the type of additional properties (e.g., for Maps)
+     */
     @SerialName("additionalProperties")
-    val additionalProperties: Boolean? = null,
+    val additionalProperties: JsonElement? = null,
     val default: JsonElement? = null,
 ) : ValuePropertyDefinition
 

--- a/kotlinx-schema-json/src/commonTest/kotlin/kotlinx/schema/json/JsonSchemaDslTest.kt
+++ b/kotlinx-schema-json/src/commonTest/kotlin/kotlinx/schema/json/JsonSchemaDslTest.kt
@@ -1,6 +1,5 @@
 package kotlinx.schema.json
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
@@ -565,7 +564,7 @@ internal class JsonSchemaDslTest {
                         array {
                             description = "Processing steps"
                             ofObject {
-                                additionalProperties = false
+                                additionalProperties = kotlinx.serialization.json.JsonPrimitive(false)
                                 property("explanation") {
                                     required = true
                                     string {
@@ -622,7 +621,7 @@ internal class JsonSchemaDslTest {
         val stepsProp = deserialized.schema.properties["steps"] as ArrayPropertyDefinition
         val itemsObj = stepsProp.items as ObjectPropertyDefinition
         itemsObj.required shouldBe listOf("explanation", "output")
-        itemsObj.additionalProperties shouldBe false
+        itemsObj.additionalProperties shouldBe kotlinx.serialization.json.JsonPrimitive(false)
     }
 
     @Test

--- a/kotlinx-schema-json/src/commonTest/kotlin/kotlinx/schema/json/JsonSchemaSerializationTest.kt
+++ b/kotlinx-schema-json/src/commonTest/kotlin/kotlinx/schema/json/JsonSchemaSerializationTest.kt
@@ -242,7 +242,7 @@ internal class JsonSchemaSerializationTest {
         // Schema validation
         val schemaDefinition = schema.schema
         schemaDefinition.type shouldBe "object"
-        schemaDefinition.additionalProperties shouldBe false
+        schemaDefinition.additionalProperties shouldBe kotlinx.serialization.json.JsonPrimitive(false)
         schemaDefinition.required shouldHaveSize 3
         schemaDefinition.required shouldBe listOf("id", "email", "status")
 
@@ -344,7 +344,7 @@ internal class JsonSchemaSerializationTest {
                         this as StringPropertyDefinition
                         type shouldBe listOf("string")
                     }
-                    additionalProperties shouldBe false
+                    additionalProperties shouldBe kotlinx.serialization.json.JsonPrimitive(false)
                 }
             }
         }


### PR DESCRIPTION
- Added ReflectionIntrospector to analyze class metadata, including properties, types, and `@Description` annotations.
- Implemented JsonSchemaEmitter to convert the internal type representation (`TypeGraph`) into a standard JSON Schema model. Created JsonSchemaConfig to allow customization of generator behavior (WIP)
- Introduced ReflectionJsonSchemaGenerator for generating JSON Schemas directly from Kotlin classes using reflection.
- Support JsonObject in `JsonSchema.additionalProperties`
- Included unit tests in ReflectionJsonSchemaGeneratorTest to verify correct schema output for various scenarios.
- Updated dependencies, README, and build scripts to support the new module and functionality.