### PR TITLE
Refactor: Rename SchemaEmitter to TypeGraphTransformer

### DIFF
--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/AbstractSchemaGenerator.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/AbstractSchemaGenerator.kt
@@ -1,7 +1,7 @@
 package kotlinx.schema.generator.core
 
-import kotlinx.schema.generator.core.ir.SchemaEmitter
 import kotlinx.schema.generator.core.ir.SchemaIntrospector
+import kotlinx.schema.generator.core.ir.TypeGraphTransformer
 
 /**
  * Abstract base class for generating schemas by combining introspection and representation logic.
@@ -13,14 +13,14 @@ import kotlinx.schema.generator.core.ir.SchemaIntrospector
  */
 public abstract class AbstractSchemaGenerator<T : Any, R : Any>(
     protected val introspector: SchemaIntrospector<T>,
-    protected val emitter: SchemaEmitter<R>,
+    protected val emitter: TypeGraphTransformer<R>,
 ) : SchemaGenerator<T, R> {
     protected abstract fun getRootName(target: T): String
 
     override fun generateSchema(target: T): R {
         val graph = introspector.introspect(target)
 
-        return emitter.emit(graph, getRootName(target))
+        return emitter.transform(graph, getRootName(target))
     }
 
     override fun generateSchemaString(target: T): String {

--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/ir/SchemaEmitter.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/ir/SchemaEmitter.kt
@@ -1,9 +1,0 @@
-package kotlinx.schema.generator.core.ir
-
-/** Emitter that converts a [TypeGraph] to a target representation (e.g., JSON Schema). */
-public interface SchemaEmitter<R> {
-    public fun emit(
-        graph: TypeGraph,
-        rootName: String,
-    ): R
-}

--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/ir/TypeGraphTransformer.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/ir/TypeGraphTransformer.kt
@@ -1,0 +1,23 @@
+package kotlinx.schema.generator.core.ir
+
+/**
+ * Converts a [TypeGraph] intermediate representation to a target schema format.
+ *
+ * Implementations of this interface transform the language-agnostic IR produced by
+ * [SchemaIntrospector] into specific schema formats like JSON Schema, OpenAPI, Avro, etc.
+ *
+ * Example:
+ * ```kotlin
+ * class MySchemaTransformer : TypeGraphTransformer<MySchema> {
+ *     override fun transform(graph: TypeGraph, rootName: String): MySchema {
+ *         // Convert graph to MySchema format
+ *     }
+ * }
+ * ```
+ */
+public interface TypeGraphTransformer<R> {
+    public fun transform(
+        graph: TypeGraph,
+        rootName: String,
+    ): R
+}

--- a/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/core/AbstractSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/core/AbstractSchemaGeneratorTest.kt
@@ -4,9 +4,9 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import kotlinx.schema.generator.core.ir.SchemaEmitter
 import kotlinx.schema.generator.core.ir.SchemaIntrospector
 import kotlinx.schema.generator.core.ir.TypeGraph
+import kotlinx.schema.generator.core.ir.TypeGraphTransformer
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -18,7 +18,7 @@ class AbstractSchemaGeneratorTest {
     private lateinit var introspector: SchemaIntrospector<KClass<*>>
 
     @MockK
-    private lateinit var emitter: SchemaEmitter<Map<String, String>>
+    private lateinit var emitter: TypeGraphTransformer<Map<String, String>>
 
     @MockK
     private lateinit var typeGraph: TypeGraph
@@ -46,7 +46,7 @@ class AbstractSchemaGeneratorTest {
     fun generateSchema() {
         every { introspector.introspect(AbstractSchemaGeneratorTest::class) } returns typeGraph
         val expectedSchema = mapOf("schema" to "{}")
-        every { emitter.emit(typeGraph, rootName) } returns expectedSchema
+        every { emitter.transform(typeGraph, rootName) } returns expectedSchema
 
         val result = generator.generateSchema(AbstractSchemaGeneratorTest::class)
 
@@ -57,7 +57,7 @@ class AbstractSchemaGeneratorTest {
     fun generateSchemaString() {
         every { introspector.introspect(AbstractSchemaGeneratorTest::class) } returns typeGraph
         val expectedSchema = mapOf("schema" to "{}")
-        every { emitter.emit(typeGraph, rootName) } returns expectedSchema
+        every { emitter.transform(typeGraph, rootName) } returns expectedSchema
 
         val result = generator.generateSchemaString(AbstractSchemaGeneratorTest::class)
 

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/ReflectionJsonSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/ReflectionJsonSchemaGenerator.kt
@@ -9,10 +9,10 @@ import kotlin.reflect.KClass
 public class ReflectionJsonSchemaGenerator
     @JvmOverloads
     public constructor(
-        jsonSchemaConfig: JsonSchemaConfig = JsonSchemaConfig.DEFAULT,
+        jsonSchemaConfig: JsonSchemaConfig = JsonSchemaConfig.Default,
     ) : AbstractSchemaGenerator<KClass<out Any>, JsonSchema>(
             introspector = ReflectionIntrospector,
-            emitter = JsonSchemaEmitter(config = jsonSchemaConfig),
+            emitter = TypeGraphToJsonSchemaTransformer(config = jsonSchemaConfig),
         ) {
         override fun getRootName(target: KClass<out Any>): String = target.qualifiedName ?: "Anonymous"
 
@@ -21,4 +21,16 @@ public class ReflectionJsonSchemaGenerator
         override fun schemaType(): KClass<JsonSchema> = JsonSchema::class
 
         override fun encodeToString(schema: JsonSchema): String = Json.encodeToString(schema)
+
+        public companion object {
+            /**
+             * A default instance of the [ReflectionJsonSchemaGenerator] class, preconfigured
+             * with the default settings defined in [JsonSchemaConfig.Default].
+             *
+             * This instance can be used to generate JSON schema representations of Kotlin
+             * objects using reflection-based introspection. It simplifies the creation
+             * of schemas without requiring explicit configuration.
+             */
+            public val Default: ReflectionJsonSchemaGenerator = ReflectionJsonSchemaGenerator()
+        }
     }

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonSchemaTransformer.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonSchemaTransformer.kt
@@ -7,8 +7,8 @@ import kotlinx.schema.generator.core.ir.MapNode
 import kotlinx.schema.generator.core.ir.ObjectNode
 import kotlinx.schema.generator.core.ir.PrimitiveKind
 import kotlinx.schema.generator.core.ir.PrimitiveNode
-import kotlinx.schema.generator.core.ir.SchemaEmitter
 import kotlinx.schema.generator.core.ir.TypeGraph
+import kotlinx.schema.generator.core.ir.TypeGraphTransformer
 import kotlinx.schema.generator.core.ir.TypeNode
 import kotlinx.schema.generator.core.ir.TypeRef
 import kotlinx.schema.json.ArrayPropertyDefinition
@@ -38,18 +38,25 @@ public data class JsonSchemaConfig(
     val json: Json = Json,
 ) {
     public companion object {
-        public val DEFAULT: JsonSchemaConfig = JsonSchemaConfig()
+        /**
+         * Default configuration instance for JSON Schema generation.
+         *
+         * Provides a preconfigured instance of [JsonSchemaConfig] with the default settings.
+         *
+         * Can be used as a baseline configuration or as a convenient default for most use cases.
+         */
+        public val Default: JsonSchemaConfig = JsonSchemaConfig()
     }
 }
 
 @Suppress("TooManyFunctions")
-public class JsonSchemaEmitter
+public class TypeGraphToJsonSchemaTransformer
     @JvmOverloads
     public constructor(
-        public val config: JsonSchemaConfig = JsonSchemaConfig.DEFAULT,
+        public val config: JsonSchemaConfig = JsonSchemaConfig.Default,
         private val json: Json = Json { encodeDefaults = false },
-    ) : SchemaEmitter<JsonSchema> {
-        override fun emit(
+    ) : TypeGraphTransformer<JsonSchema> {
+        override fun transform(
             graph: TypeGraph,
             rootName: String,
         ): JsonSchema {
@@ -200,9 +207,8 @@ public class JsonSchemaEmitter
             // Convert all properties
             val properties =
                 node.properties.associate { property ->
-                    val typeRef = property.type
                     val isNullable =
-                        when (typeRef) {
+                        when (val typeRef = property.type) {
                             is TypeRef.Inline -> typeRef.nullable
                             is TypeRef.Ref -> typeRef.nullable
                         }

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/internal/IrStandardJsonSchemaEmitter.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/internal/IrStandardJsonSchemaEmitter.kt
@@ -7,8 +7,8 @@ import kotlinx.schema.generator.core.ir.ObjectNode
 import kotlinx.schema.generator.core.ir.PolymorphicNode
 import kotlinx.schema.generator.core.ir.PrimitiveKind
 import kotlinx.schema.generator.core.ir.PrimitiveNode
-import kotlinx.schema.generator.core.ir.SchemaEmitter
 import kotlinx.schema.generator.core.ir.TypeGraph
+import kotlinx.schema.generator.core.ir.TypeGraphTransformer
 import kotlinx.schema.generator.core.ir.TypeId
 import kotlinx.schema.generator.core.ir.TypeNode
 import kotlinx.schema.generator.core.ir.TypeRef
@@ -20,9 +20,9 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
 /** Emits JSON Schema from Schema IR following the Standard rules used previously. */
-public class IrStandardJsonSchemaEmitter : SchemaEmitter<JsonObject> {
+public class IrStandardJsonSchemaEmitter : TypeGraphTransformer<JsonObject> {
     @Suppress("CyclomaticComplexMethod", "LongMethod", "NestedBlockDepth")
-    override fun emit(
+    override fun transform(
         graph: TypeGraph,
         rootName: String,
     ): JsonObject {

--- a/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/ReflectionJsonSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/ReflectionJsonSchemaGeneratorTest.kt
@@ -1,15 +1,7 @@
 package kotlinx.schema.generator.json
 
 import io.kotest.assertions.json.shouldEqualJson
-import io.kotest.matchers.booleans.shouldBeTrue
-import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.shouldBe
 import kotlinx.schema.Description
-import kotlinx.schema.json.ArrayPropertyDefinition
-import kotlinx.schema.json.NumericPropertyDefinition
-import kotlinx.schema.json.ObjectPropertyDefinition
-import kotlinx.schema.json.StringPropertyDefinition
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 
@@ -42,7 +34,7 @@ class ReflectionJsonSchemaGeneratorTest {
         )
 
         val schema =
-            ReflectionJsonSchemaGenerator().generateSchema(Person::class)
+            ReflectionJsonSchemaGenerator.Default.generateSchema(Person::class)
 
         // language=json
         val expectedSchema = """ 


### PR DESCRIPTION
Improve semantic clarity and API ergonomics:

- Rename SchemaEmitter to TypeGraphTransformer. Rename emit() to transform()
- Rename JsonSchemaEmitter to TypeGraphToJsonSchemaTransformer
- Rename JsonSchemaConfig.DEFAULT to JsonSchemaConfig.Default
- Add ReflectionJsonSchemaGenerator.Default companion object
- Update README with reflection-based generator examples
- Add KDocs to public APIs