### PR TITLE
refactor(schema): use ObjectPropertyDefinition for function parameters to match JSON Schema semantics

### DIFF
--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToFunctionCallingSchemaTransformer.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToFunctionCallingSchemaTransformer.kt
@@ -15,7 +15,6 @@ import kotlinx.schema.json.BooleanPropertyDefinition
 import kotlinx.schema.json.FunctionCallingSchema
 import kotlinx.schema.json.NumericPropertyDefinition
 import kotlinx.schema.json.ObjectPropertyDefinition
-import kotlinx.schema.json.ParametersDefinition
 import kotlinx.schema.json.PropertyDefinition
 import kotlinx.schema.json.StringPropertyDefinition
 import kotlinx.serialization.json.Json
@@ -93,9 +92,10 @@ public class TypeGraphToFunctionCallingSchemaTransformer
                 name = node.name,
                 description = node.description ?: "",
                 parameters =
-                    ParametersDefinition(
+                    ObjectPropertyDefinition(
                         properties = properties,
                         required = node.properties.map { it.name },
+                        additionalProperties = JsonPrimitive(false),
                     ),
             )
         }

--- a/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/FunctionCallingSchema.kt
+++ b/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/FunctionCallingSchema.kt
@@ -35,7 +35,7 @@ public data class FunctionCallingSchema(
      */
     @EncodeDefault
     public val strict: Boolean? = true,
-    public val parameters: ParametersDefinition,
+    public val parameters: ObjectPropertyDefinition,
 )
 
 /**
@@ -54,28 +54,3 @@ public fun FunctionCallingSchema.encodeToJsonObject(json: Json = Json): JsonObje
  * @return The JSON string representation of the [FunctionCallingSchema] instance.
  */
 public fun FunctionCallingSchema.encodeToString(json: Json = Json): String = json.encodeToString(this)
-
-/**
- * JSON schema defining the function's input arguments.
- *
- * See [Strict mode](https://platform.openai.com/docs/guides/function-calling?strict-mode=disabled#strict-mode)
- */
-@Serializable
-@OptIn(ExperimentalSerializationApi::class)
-public data class ParametersDefinition(
-    @EncodeDefault
-    public val properties: Map<String, PropertyDefinition> = emptyMap(),
-    @EncodeDefault
-    public val required: List<String> = emptyList(),
-    /**
-     * additionalProperties is always "false"
-     */
-    @EncodeDefault
-    public val additionalProperties: Boolean = false,
-) {
-    /**
-     * Type is always "object"
-     */
-    @EncodeDefault
-    public val type: String = "object"
-}

--- a/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchema.kt
+++ b/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchema.kt
@@ -46,6 +46,109 @@ public fun JsonSchema.encodeToJsonObject(json: Json = Json): JsonObject = json.e
 public fun JsonSchema.encodeToString(json: Json = Json): String = json.encodeToString(this)
 
 /**
+ * Interface representing a container for properties in a JSON schema.
+ */
+public interface PropertiesContainer {
+    /**
+     * Represents a map of property definitions for an object.
+     *
+     * Each entry in the map consists of a key-value pair, where the key is the name of the property
+     * (as a [String]) and the value is an instance of [PropertyDefinition], which describes the details
+     * of the property based on the JSON Schema.
+     *
+     * This property may be null, indicating that no properties are defined for the object or the properties
+     * are unavailable.
+     */
+    public val properties: Map<String, PropertyDefinition>?
+
+    /**
+     * Retrieves the boolean property definition associated with the specified property name.
+     *
+     * @param name The name of the property to fetch from the object definition.
+     * @return The corresponding [BooleanPropertyDefinition] if the property exists and is a boolean,
+     * or `null` if no such property exists or the property is not boolean property.
+     */
+    public fun booleanProperty(name: String): BooleanPropertyDefinition? =
+        properties?.get(name) as? BooleanPropertyDefinition
+
+    /**
+     * Retrieves the numeric property definition associated with the specified property name.
+     *
+     * @param name The name of the property to fetch from the object definition.
+     * @return The corresponding [NumericPropertyDefinition] if the property exists and is numeric,
+     * or `null` if no such property exists or the property is not numeric.
+     */
+    public fun numericProperty(name: String): NumericPropertyDefinition? =
+        properties?.get(name) as? NumericPropertyDefinition
+
+    /**
+     * Retrieves the string property definition associated with the specified property name.
+     *
+     * @param name The name of the property to fetch from the object definition.
+     * @return The corresponding [StringPropertyDefinition] if the property exists and is a string,
+     * or `null` if no such property exists or the property is not a string property.
+     */
+    public fun stringProperty(name: String): StringPropertyDefinition? =
+        properties?.get(name) as? StringPropertyDefinition
+
+    /**
+     * Retrieves the `object` property definition associated with the specified property name.
+     *
+     * @param name The name of the property to fetch from the object definition.
+     * @return The corresponding [ObjectPropertyDefinition] if the property exists and is an object,
+     * or `null` if no such property exists or the property is not object property.
+     */
+    public fun objectProperty(name: String): ObjectPropertyDefinition? =
+        properties?.get(name) as? ObjectPropertyDefinition
+
+    /**
+     * Retrieves the array property definition associated with the specified property name.
+     *
+     * @param name The name of the property to fetch from the object definition.
+     * @return The corresponding [ArrayPropertyDefinition] if the property exists and is an array,
+     * or `null` if no such property exists or the property is not an array.
+     */
+    public fun arrayProperty(name: String): ArrayPropertyDefinition? = properties?.get(name) as? ArrayPropertyDefinition
+
+    /**
+     * Retrieves the reference property definition associated with the specified property name.
+     *
+     * @param name The name of the property to fetch from the object definition.
+     * @return The corresponding [ReferencePropertyDefinition] if the property exists and is a reference,
+     * or `null` if no such property exists or the property is not a reference.
+     */
+    public fun referenceProperty(name: String): ReferencePropertyDefinition? =
+        properties?.get(name) as? ReferencePropertyDefinition
+
+    /**
+     * Retrieves the oneOf property definition associated with the specified property name.
+     *
+     * @param name The name of the property to fetch from the object definition.
+     * @return The corresponding [OneOfPropertyDefinition] if the property exists and is a oneOf,
+     * or `null` if no such property exists or the property is not a oneOf.
+     */
+    public fun oneOfProperty(name: String): OneOfPropertyDefinition? = properties?.get(name) as? OneOfPropertyDefinition
+
+    /**
+     * Retrieves the anyOf property definition associated with the specified property name.
+     *
+     * @param name The name of the property to fetch from the object definition.
+     * @return The corresponding [AnyOfPropertyDefinition] if the property exists and is an anyOf,
+     * or `null` if no such property exists or the property is not an anyOf.
+     */
+    public fun anyOfProperty(name: String): AnyOfPropertyDefinition? = properties?.get(name) as? AnyOfPropertyDefinition
+
+    /**
+     * Retrieves the allOf property definition associated with the specified property name.
+     *
+     * @param name The name of the property to fetch from the object definition.
+     * @return The corresponding [AllOfPropertyDefinition] if the property exists and is an allOf,
+     * or `null` if no such property exists or the property is not an allOf.
+     */
+    public fun allOfProperty(name: String): AllOfPropertyDefinition? = properties?.get(name) as? AllOfPropertyDefinition
+}
+
+/**
  * Represents a JSON Schema definition.
  *
  * @property id JSON Schema [$id](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#name-the-id-keyword)
@@ -69,7 +172,7 @@ public data class JsonSchemaDefinition(
     @SerialName($$"$schema") public val schema: String? = null,
     @EncodeDefault
     public val type: String = "object",
-    public val properties: Map<String, PropertyDefinition> = emptyMap(),
+    public override val properties: Map<String, PropertyDefinition> = emptyMap(),
     public val required: List<String> = emptyList(),
     /**
      * Defines whether additional properties are allowed and their schema.
@@ -85,7 +188,7 @@ public data class JsonSchemaDefinition(
     public val oneOf: List<PropertyDefinition>? = null,
     public val discriminator: Discriminator? = null,
     @SerialName($$"$defs") public val defs: Map<String, PropertyDefinition>? = null,
-)
+) : PropertiesContainer
 
 /**
  * Represents a property definition in a JSON Schema.
@@ -183,7 +286,7 @@ public data class ObjectPropertyDefinition(
         listOf("object"),
     override val description: String? = null,
     override val nullable: Boolean? = null,
-    val properties: Map<String, PropertyDefinition>? = null,
+    override val properties: Map<String, PropertyDefinition>? = null,
     val required: List<String>? = null,
     /**
      * Defines whether additional properties are allowed and their schema.
@@ -195,7 +298,8 @@ public data class ObjectPropertyDefinition(
      */
     @SerialName("additionalProperties") val additionalProperties: JsonElement? = null,
     val default: JsonElement? = null,
-) : ValuePropertyDefinition
+) : ValuePropertyDefinition,
+    PropertiesContainer
 
 /**
  * Represents a boolean property

--- a/kotlinx-schema-json/src/commonTest/kotlin/kotlinx/schema/json/ObjectPropertyDefinitionExtensionsTest.kt
+++ b/kotlinx-schema-json/src/commonTest/kotlin/kotlinx/schema/json/ObjectPropertyDefinitionExtensionsTest.kt
@@ -1,0 +1,143 @@
+package kotlinx.schema.json
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class ObjectPropertyDefinitionExtensionsTest {
+    @Test
+    fun `should access all types of properties in ObjectPropertyDefinition`() {
+        val schema =
+            jsonSchema {
+                name = "Test"
+                schema {
+                    property("obj") {
+                        obj {
+                            property("str") { string { description = "string description" } }
+                            property("num") { number { minimum = 10.0 } }
+                            property("bool") { boolean { } }
+                            property("nestedObj") { obj { } }
+                            property("arr") { array { minItems = 1 } }
+                            property("ref") { reference("#/defs/Other") }
+                            property("oneOf") {
+                                oneOf {
+                                    string()
+                                    integer()
+                                }
+                            }
+                            property("anyOf") {
+                                anyOf {
+                                    string()
+                                    integer()
+                                }
+                            }
+                            property("allOf") {
+                                allOf {
+                                    string()
+                                    integer()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+        val objDef = schema.schema.objectProperty("obj")
+        assertObjectPropertyDefinition(objDef)
+
+        assertNull(objDef?.stringProperty("num"))
+    }
+
+    private fun assertObjectPropertyDefinition(objDef: ObjectPropertyDefinition?) {
+        objDef.shouldNotBeNull()
+
+        objDef.stringProperty("str").shouldNotBeNull {
+            description shouldBe "string description"
+        }
+        objDef.numericProperty("num").shouldNotBeNull {
+            minimum shouldBe 10.0
+        }
+        objDef.booleanProperty("bool").shouldNotBeNull {
+            type shouldBe listOf("boolean")
+        }
+        objDef.objectProperty("nestedObj").shouldNotBeNull()
+        objDef.arrayProperty("arr").shouldNotBeNull {
+            minItems shouldBe 1u
+        }
+        objDef.referenceProperty("ref").shouldNotBeNull {
+            ref shouldBe "#/defs/Other"
+        }
+        objDef.oneOfProperty("oneOf").shouldNotBeNull {
+            oneOf.size shouldBe 2
+        }
+        objDef.anyOfProperty("anyOf").shouldNotBeNull {
+            anyOf.size shouldBe 2
+        }
+        objDef.allOfProperty("allOf").shouldNotBeNull {
+            allOf.size shouldBe 2
+        }
+    }
+
+    @Test
+    fun `should access all types of properties in JsonSchemaDefinition`() {
+        val schema =
+            jsonSchema {
+                name = "Test"
+                schema {
+                    property("str") { string { description = "string description" } }
+                    property("num") { number { minimum = 10.0 } }
+                    property("bool") { boolean { } }
+                    property("obj") { obj { } }
+                    property("arr") { array { minItems = 1 } }
+                    property("ref") { reference("#/defs/Other") }
+                    property("oneOf") {
+                        oneOf {
+                            string()
+                            integer()
+                        }
+                    }
+                    property("anyOf") {
+                        anyOf {
+                            string()
+                            integer()
+                        }
+                    }
+                    property("allOf") {
+                        allOf {
+                            string()
+                            integer()
+                        }
+                    }
+                }
+            }
+
+        val schemaDef = schema.schema
+
+        schemaDef.stringProperty("str").shouldNotBeNull {
+            description shouldBe "string description"
+        }
+        schemaDef.numericProperty("num").shouldNotBeNull {
+            minimum shouldBe 10.0
+        }
+        schemaDef.booleanProperty("bool").shouldNotBeNull()
+        schemaDef.objectProperty("obj").shouldNotBeNull()
+        schemaDef.arrayProperty("arr").shouldNotBeNull {
+            minItems shouldBe 1u
+        }
+        schemaDef.referenceProperty("ref").shouldNotBeNull {
+            ref shouldBe "#/defs/Other"
+        }
+        schemaDef.oneOfProperty("oneOf").shouldNotBeNull {
+            oneOf.size shouldBe 2
+        }
+        schemaDef.anyOfProperty("anyOf").shouldNotBeNull {
+            anyOf.size shouldBe 2
+        }
+        schemaDef.allOfProperty("allOf").shouldNotBeNull {
+            allOf.size shouldBe 2
+        }
+
+        assertNull(schemaDef.stringProperty("num"))
+    }
+}


### PR DESCRIPTION
# Use ObjectPropertyDefinition for function parameters to match JSON Schema semantics

  **BREAKING CHANGE:** `FunctionCallingSchema.parameters` type changed from
  `ParametersDefinition` to `ObjectPropertyDefinition` to correctly represent
  JSON Schema object definitions.

  - Remove `ParametersDefinition` class that duplicated ObjectPropertyDefinition
  - Introduce `PropertiesContainer` interface with type-safe property accessors
  - Implement `PropertiesContainer` in `JsonSchemaDefinition` and `ObjectPropertyDefinition`
  - Update `TypeGraphToFunctionCallingSchemaTransformer` to use `ObjectPropertyDefinition`
  - Add explicit `additionalProperties = JsonPrimitive(false)` for strict mode
  - Update tests to use nullable properties and typed accessors
  - Add `ObjectPropertyDefinitionExtensionsTest` for comprehensive coverage

### Migration:

  - Access properties: `schema.parameters.properties?.get("name")` or use typed accessors: `schema.parameters.stringProperty("name")`
  - Type field now supports unions (unchanged JSON serialization)
  - additionalProperties now supports schema objects (currently uses false)

  **Rationale:** The OpenAI Function Calling format's `parameters` field IS a
  JSON Schema object definition, not a specialized type. Using separate classes
  for the same concept (ParametersDefinition vs ObjectPropertyDefinition)
  violated DRY principle and had overly restrictive types that didn't match
  JSON Schema semantics. This consolidation:

  1. Correctly models JSON Schema specification
  2. Eliminates conceptual duplication (28 lines)
  3. Enables future extensibility (e.g., schema-typed additionalProperties)
  4. Provides consistent API across all JSON Schema objects
  5. Adds type-safe property accessor methods

### Related Issues
Required for #46 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test addition or update
- [x] Code removal/cleanup

## How Has This Been Tested?

**Testing checklist:**
- [x] All existing tests pass locally
- [x] Unit tests added/updated

---

## Pre-Submission Checklist
<!-- Complete before requesting review -->


### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any commented-out code and debug statements
- [x] My code generates no new warnings or errors

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if needed
- [ ] I have updated relevant comments in the code

### Testing
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have tested edge cases and error scenarios

### Dependencies & Breaking Changes
- [ ] I have checked for dependency updates
- [ ] I have documented any breaking changes
- [ ] Backward compatibility is maintained (or properly documented if not)

### Focus & Scope
- [x] This PR stays focused on a single concern
- [x] I haven't included unrelated changes or "drive-by" fixes
- [x] The PR description accurately reflects ALL the changes made

## Additional Notes
<!-- Any additional information that reviewers should know -->

---

<!--
Thank you for contributing!
Remember: Smaller PRs → Faster reviews → Shorter cycles → Better outcomes
-->