### PR TITLE
refactor(schema): Introduce configurable required field strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,7 +916,7 @@ val schema: FunctionCallingSchema = greetPersonJsonSchema()
 
 #### Generated Schema
 
-The generated schema is identical to the runtime reflection format:
+The generated schema follows OpenAI Strict Mode by default (all parameters required):
 
 ```json
 {
@@ -936,17 +936,20 @@ The generated schema is identical to the runtime reflection format:
         "description": "Optional greeting prefix (e.g., 'Hello', 'Hi')"
       }
     },
-    "required": ["name"],
+    "required": ["name", "greeting"],
     "additionalProperties": false
   }
 }
 ```
 
+**Note**: Both parameters appear in `required` even though `greeting` has a default value. 
+This is [OpenAI Strict Mode](https://platform.openai.com/docs/guides/function-calling?strict-mode=enabled#strict-mode) behavior.
+
 #### Key Differences from Runtime Reflection
 
 - **Compile-time generation**: Schemas are generated during compilation, not at runtime
 - **Zero runtime overhead**: No reflection or runtime introspection needed
-- **Default value limitation**: Function parameter default values (e.g., `greeting: String = "Hello"`) are detected but their actual values cannot be extracted at compile time due to [KSP limitations](https://github.com/google/ksp/issues/1868). Parameters with defaults are marked as optional (excluded from `required` array)
+- **Default value limitation**: Function parameter default values (e.g., `greeting: String = "Hello"`) cannot be extracted at compile time due to [KSP limitations](https://github.com/google/ksp/issues/1868). With the default `ALL_REQUIRED` strategy (OpenAI Strict Mode), all parameters are marked as required regardless of defaults. Use the `NON_NULLABLE_REQUIRED` strategy if you need nullable parameters to be optional
 - **All function types supported**: Works with top-level, instance, companion object, and suspend functions
 - **Generated function naming**: For a function `myFunction()`, generates `myFunctionJsonSchemaString()` and optionally `myFunctionJsonSchema()`
 

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/ReflectionFunctionCallingSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/ReflectionFunctionCallingSchemaGenerator.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.KClass
 public class ReflectionFunctionCallingSchemaGenerator
     @JvmOverloads
     public constructor(
-        json: Json = Json,
+        private val json: Json = Json,
     ) : AbstractSchemaGenerator<KCallable<*>, FunctionCallingSchema>(
             introspector = ReflectionFunctionIntrospector,
             typeGraphTransformer = TypeGraphToFunctionCallingSchemaTransformer(json),
@@ -35,7 +35,7 @@ public class ReflectionFunctionCallingSchemaGenerator
 
         override fun schemaType(): KClass<FunctionCallingSchema> = FunctionCallingSchema::class
 
-        override fun encodeToString(schema: FunctionCallingSchema): String = Json.encodeToString(schema)
+        override fun encodeToString(schema: FunctionCallingSchema): String = json.encodeToString(schema)
 
         public companion object {
             /**

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/RequiredFieldStrategy.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/RequiredFieldStrategy.kt
@@ -1,0 +1,73 @@
+package kotlinx.schema.generator.json
+
+/**
+ * Strategy for determining which parameters should be marked as required in the function schema.
+ *
+ * This strategy ONLY affects which fields are included in the `required` array.
+ * Other OpenAI Strict Mode features (additionalProperties: false, strict: true flag)
+ * are always enabled.
+ *
+ * @see [OpenAI Strict Mode](https://platform.openai.com/docs/guides/function-calling?strict-mode=enabled#strict-mode)
+ */
+public enum class RequiredFieldStrategy {
+    /**
+     * OpenAI Strict Mode (Default): All parameters are marked as required.
+     *
+     * In strict mode, all parameters must be present in the `required` array.
+     * Optional/nullable parameters are represented using union types with null: `["string", "null"]`.
+     *
+     * Example:
+     * ```kotlin
+     * fun writeLog(level: String, exception: String? = null)
+     * ```
+     * Generates:
+     * ```json
+     * {
+     *   "required": ["level", "exception"],
+     *   "properties": {
+     *     "level": { "type": "string" },
+     *     "exception": { "type": ["string", "null"] }
+     *   }
+     * }
+     * ```
+     *
+     * This ensures the model always provides all fields, even if they're null.
+     */
+    ALL_REQUIRED,
+
+    /**
+     * Non-strict mode: Only non-nullable parameters are marked as required.
+     *
+     * Nullable parameters are excluded from the required list, allowing them to be omitted entirely.
+     * Use this when you want nullable parameters to be truly optional (not required with null value).
+     *
+     * Example:
+     * ```kotlin
+     * fun writeLog(level: String, exception: String? = null)
+     * ```
+     * Generates:
+     * ```json
+     * {
+     *   "required": ["level"],
+     *   "properties": {
+     *     "level": { "type": "string" },
+     *     "exception": { "type": ["string", "null"] }
+     *   }
+     * }
+     * ```
+     */
+    NON_NULLABLE_REQUIRED,
+
+    /**
+     * Use the DefaultPresence from the introspector to determine required fields.
+     *
+     * Parameters with DefaultPresence.Required are marked as required.
+     * Parameters with DefaultPresence.Absent are excluded from required.
+     *
+     * **Note**: This strategy doesn't work reliably with KSP because KSP cannot detect
+     * default values in the same compilation unit. For KSP, this behaves the same as ALL_REQUIRED.
+     *
+     * Use this strategy with reflection-based introspection where default values are detectable.
+     */
+    USE_DEFAULT_PRESENCE,
+}

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/KspFunctionSchemaGenerator.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/KspFunctionSchemaGenerator.kt
@@ -30,8 +30,8 @@ internal class KspFunctionSchemaGenerator :
     ) {
     private val json =
         Json {
-            prettyPrint = true
-            encodeDefaults = true
+            prettyPrint = false
+            encodeDefaults = false
         }
 
     override fun getRootName(target: KSFunctionDeclaration): String {

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspClassIntrospector.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspClassIntrospector.kt
@@ -157,7 +157,7 @@ internal class KspClassIntrospector : SchemaIntrospector<KSClassDeclaration> {
                             val name = p.name?.asString() ?: return@forEach
                             val pType = p.type.resolve()
                             val desc =
-                                p.annotations.mapNotNull { it.descriptionOrNull() }.firstOrNull() // todo: gen kdoc
+                                p.annotations.firstNotNullOfOrNull { it.descriptionOrNull() } // todo: gen kdoc
                             val tref = toRef(pType)
                             val presence = if (p.hasDefault) DefaultPresence.Absent else DefaultPresence.Required
                             if (!p.hasDefault) required += name
@@ -178,7 +178,7 @@ internal class KspClassIntrospector : SchemaIntrospector<KSClassDeclaration> {
                             val name = prop.simpleName.asString()
                             val pType = prop.type.resolve()
                             val desc =
-                                prop.annotations.mapNotNull { it.descriptionOrNull() }.firstOrNull()
+                                prop.annotations.firstNotNullOfOrNull { it.descriptionOrNull() }
                                     ?: prop.descriptionFromKdoc()
                             val tref = toRef(pType)
                             // KSP doesn't easily provide default presence here; treat as required conservatively

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/descriptions.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/descriptions.kt
@@ -33,5 +33,5 @@ internal fun KSAnnotation.descriptionOrNull(): String? {
 }
 
 internal fun KSAnnotated.descriptionOrDefault(defaultValue: String? = null): String? =
-    annotations.mapNotNull { it.descriptionOrNull() }.firstOrNull()
+    annotations.firstNotNullOfOrNull { it.descriptionOrNull() }
         ?: defaultValue

--- a/kotlinx-schema-ksp/src/test/kotlin/kotlinx/schema/ksp/KspFunctionSchemaGeneratorTest.kt
+++ b/kotlinx-schema-ksp/src/test/kotlin/kotlinx/schema/ksp/KspFunctionSchemaGeneratorTest.kt
@@ -1,9 +1,7 @@
 package kotlinx.schema.ksp
 
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
 
 /**
  * Tests for KSP-based function schema generation.
@@ -13,14 +11,6 @@ import kotlin.test.assertTrue
  * and structure of the generator.
  */
 class KspFunctionSchemaGeneratorTest {
-    @Test
-    fun `KspFunctionSchemaGenerator should be instantiable`() {
-        val generator = KspFunctionSchemaGenerator()
-        generator shouldNotBeNull {
-            assertTrue(this is KspFunctionSchemaGenerator)
-        }
-    }
-
     @Test
     fun `KspFunctionSchemaGenerator should have correct types`() {
         val generator = KspFunctionSchemaGenerator()

--- a/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/functions/CompanionObjectFunctionsTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/functions/CompanionObjectFunctionsTest.kt
@@ -1,12 +1,6 @@
 package kotlinx.schema.integration.functions
 
 import io.kotest.assertions.json.shouldEqualJson
-import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 
 /**
@@ -21,135 +15,208 @@ import kotlin.test.Test
 class CompanionObjectFunctionsTest {
     @Test
     fun `DatabaseConnection create generates correct schema`() {
-        val schemaString = createJsonSchemaString()
-        val schema = createJsonSchema()
+        val schema = createJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-        parsed["name"]?.jsonPrimitive?.content shouldBe "create"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "database connection"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["host"].shouldNotBeNull()
-        properties["port"].shouldNotBeNull()
-        properties["database"].shouldNotBeNull()
-        properties["timeout"].shouldNotBeNull()
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "create",
+              "description": "Creates a new database connection",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "description": "Database host"
+                  },
+                  "port": {
+                    "type": "integer",
+                    "description": "Database port"
+                  },
+                  "database": {
+                    "type": "string",
+                    "description": "Database name"
+                  },
+                  "timeout": {
+                    "type": "integer",
+                    "description": "Connection timeout in seconds"
+                  }
+                },
+                "required": ["host", "port", "database", "timeout"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `DatabaseConnection connectAsync suspend function generates correct schema`() {
-        val schemaString = connectAsyncJsonSchemaString()
-        val schema = connectAsyncJsonSchema()
+        val schema = connectAsyncJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-        parsed["name"]?.jsonPrimitive?.content shouldBe "connectAsync"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "asynchronously"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["host"].shouldNotBeNull()
-        properties["port"].shouldNotBeNull()
-        properties["username"].shouldNotBeNull()
-        properties["password"].shouldNotBeNull()
-        properties["options"].shouldNotBeNull()
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "connectAsync",
+              "description": "Establishes a database connection asynchronously",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "description": "Database host"
+                  },
+                  "port": {
+                    "type": "integer",
+                    "description": "Database port"
+                  },
+                  "username": {
+                    "type": "string",
+                    "description": "Username"
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Password"
+                  },
+                  "options": {
+                    "type": ["object", "null"],
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Connection options"
+                  }
+                },
+                "required": ["host", "port", "username", "password", "options"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `ApiClient build generates correct schema`() {
-        val schemaString = buildJsonSchemaString()
-        val schema = buildJsonSchema()
+        val schema = buildJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["name"]?.jsonPrimitive?.content shouldBe "build"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "API client"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["baseUrl"].shouldNotBeNull()
-        properties["apiKey"].shouldNotBeNull()
-        properties["timeout"].shouldNotBeNull()
-        properties["debug"].shouldNotBeNull()
-        properties["headers"].shouldNotBeNull()
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "build",
+              "description": "Builds an API client with configuration",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "baseUrl": {
+                    "type": "string",
+                    "description": "API base URL"
+                  },
+                  "apiKey": {
+                    "type": "string",
+                    "description": "API key for authentication"
+                  },
+                  "timeout": {
+                    "type": "integer",
+                    "description": "Request timeout in milliseconds"
+                  },
+                  "debug": {
+                    "type": "boolean",
+                    "description": "Whether to enable debug logging"
+                  },
+                  "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Custom headers"
+                  }
+                },
+                "required": ["baseUrl", "apiKey", "timeout", "debug", "headers"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `ApiClient initializeAsync suspend function generates correct schema`() {
-        val schemaString = initializeAsyncJsonSchemaString()
-        val schema = initializeAsyncJsonSchema()
+        val schema = initializeAsyncJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["name"]?.jsonPrimitive?.content shouldBe "initializeAsync"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "asynchronously"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["baseUrl"].shouldNotBeNull()
-        properties["apiKey"].shouldNotBeNull()
-        properties["verifySSL"].shouldNotBeNull()
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "initializeAsync",
+              "description": "Initializes API client asynchronously with health check",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "baseUrl": {
+                    "type": "string",
+                    "description": "API base URL"
+                  },
+                  "apiKey": {
+                    "type": "string",
+                    "description": "API key"
+                  },
+                  "verifySSL": {
+                    "type": "boolean",
+                    "description": "Whether to verify SSL certificates"
+                  }
+                },
+                "required": ["baseUrl", "apiKey", "verifySSL"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `DataValidator validateAsync suspend function generates correct schema`() {
-        val schemaString = validateAsyncJsonSchemaString()
-        val schema = validateAsyncJsonSchema()
+        val schema = validateAsyncJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["name"]?.jsonPrimitive?.content shouldBe "validateAsync"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "asynchronously"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["data"].shouldNotBeNull()
-        properties["endpoints"].shouldNotBeNull()
-        properties["timeout"].shouldNotBeNull()
-    }
-
-    @Test
-    fun `all companion object function schemas have correct structure`() {
-        val schemas = listOf(
-            createJsonSchemaString(),
-            testConnectionJsonSchemaString(),
-            connectAsyncJsonSchemaString(),
-            closeAllConnectionsJsonSchemaString(),
-            buildJsonSchemaString(),
-            createDefaultJsonSchemaString(),
-            initializeAsyncJsonSchemaString(),
-            discoverEndpointsJsonSchemaString(),
-            validateEmailJsonSchemaString(),
-            validateJsonSchemaString(),
-            validateAsyncJsonSchemaString(),
-            batchValidateJsonSchemaString(),
-        )
-
-        schemas.forEach { schemaString ->
-            val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-            // Verify FunctionCallingSchema structure
-            parsed["type"].shouldNotBeNull()
-            parsed["name"].shouldNotBeNull()
-            parsed["parameters"].shouldNotBeNull()
-
-            parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-
-            // Verify parameters object
-            val parameters = parsed["parameters"]?.jsonObject.shouldNotBeNull()
-            parameters["type"].shouldNotBeNull()
-            parameters["properties"].shouldNotBeNull()
-            parameters["required"].shouldNotBeNull()
-
-            parameters["type"]?.jsonPrimitive?.content shouldBe "object"
-        }
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "validateAsync",
+              "description": "Validates data asynchronously with remote API checks",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Data to validate"
+                  },
+                  "endpoints": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Remote validation endpoints"
+                  },
+                  "timeout": {
+                    "type": "integer",
+                    "description": "Timeout for remote checks in milliseconds"
+                  }
+                },
+                "required": ["data", "endpoints", "timeout"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 }

--- a/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/functions/InstanceFunctionsTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/functions/InstanceFunctionsTest.kt
@@ -1,12 +1,6 @@
 package kotlinx.schema.integration.functions
 
 import io.kotest.assertions.json.shouldEqualJson
-import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 
 /**
@@ -21,108 +15,114 @@ import kotlin.test.Test
 class InstanceFunctionsTest {
     @Test
     fun `UserService registerUser generates correct schema`() {
-        val schemaString = registerUserJsonSchemaString()
-        val schema = registerUserJsonSchema()
+        val schema = registerUserJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-        parsed["name"]?.jsonPrimitive?.content shouldBe "registerUser"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "Registers a new user"
-
-        val properties =
-            parsed["parameters"]
-                ?.jsonObject
-                ?.get("properties")
-                ?.jsonObject
-                .shouldNotBeNull()
-        properties["username"].shouldNotBeNull()
-        properties["email"].shouldNotBeNull()
-        properties["age"].shouldNotBeNull()
-        properties["sendWelcomeEmail"].shouldNotBeNull()
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "registerUser",
+              "description": "Registers a new user in the system",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "description": "Username for the new account"
+                  },
+                  "email": {
+                    "type": "string",
+                    "description": "Email address"
+                  },
+                  "age": {
+                    "type": ["integer", "null"],
+                    "description": "User's age"
+                  },
+                  "sendWelcomeEmail": {
+                    "type": "boolean",
+                    "description": "Whether to send welcome email"
+                  }
+                },
+                "required": ["username", "email", "age", "sendWelcomeEmail"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `UserService authenticateUser suspend function generates correct schema`() {
-        val schemaString = authenticateUserJsonSchemaString()
-        val schema = authenticateUserJsonSchema()
+        val schema = authenticateUserJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-        parsed["name"]?.jsonPrimitive?.content shouldBe "authenticateUser"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "asynchronously"
-
-        val properties =
-            parsed["parameters"]
-                ?.jsonObject
-                ?.get("properties")
-                ?.jsonObject
-                .shouldNotBeNull()
-        properties["identifier"].shouldNotBeNull()
-        properties["password"].shouldNotBeNull()
-        properties["rememberMe"].shouldNotBeNull()
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "authenticateUser",
+              "description": "Authenticates a user asynchronously",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "identifier": {
+                    "type": "string",
+                    "description": "Username or email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Password"
+                  },
+                  "rememberMe": {
+                    "type": "boolean",
+                    "description": "Remember session"
+                  }
+                },
+                "required": ["identifier", "password", "rememberMe"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `ProductRepository saveProduct suspend function generates correct schema`() {
-        val schemaString = saveProductJsonSchemaString()
-        val schema = saveProductJsonSchema()
+        val schema = saveProductJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["name"]?.jsonPrimitive?.content shouldBe "saveProduct"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "asynchronously"
-
-        val properties =
-            parsed["parameters"]
-                ?.jsonObject
-                ?.get("properties")
-                ?.jsonObject
-                .shouldNotBeNull()
-        properties["id"].shouldNotBeNull()
-        properties["name"].shouldNotBeNull()
-        properties["price"].shouldNotBeNull()
-        properties["stock"].shouldNotBeNull()
-    }
-
-    @Test
-    fun `all instance function schemas have correct structure`() {
-        val schemas =
-            listOf(
-                registerUserJsonSchemaString(),
-                updateProfileJsonSchemaString(),
-                authenticateUserJsonSchemaString(),
-                loadUserPreferencesJsonSchemaString(),
-                deleteAccountJsonSchemaString(),
-                sendBulkNotificationJsonSchemaString(),
-                findByCategoryJsonSchemaString(),
-                saveProductJsonSchemaString(),
-            )
-
-        schemas.forEach { schemaString ->
-            val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-            // Verify FunctionCallingSchema structure
-            parsed["type"].shouldNotBeNull()
-            parsed["name"].shouldNotBeNull()
-            parsed["parameters"].shouldNotBeNull()
-
-            parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-
-            // Verify parameters object
-            val parameters = parsed["parameters"]?.jsonObject.shouldNotBeNull()
-            parameters["type"].shouldNotBeNull()
-            parameters["properties"].shouldNotBeNull()
-            parameters["required"].shouldNotBeNull()
-
-            parameters["type"]?.jsonPrimitive?.content shouldBe "object"
-        }
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "saveProduct",
+              "description": "Saves a product to the database asynchronously",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": ["integer", "null"],
+                    "description": "Product ID (null for new products)"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Product name"
+                  },
+                  "price": {
+                    "type": "number",
+                    "description": "Product price"
+                  },
+                  "stock": {
+                    "type": "integer",
+                    "description": "Stock quantity"
+                  }
+                },
+                "required": ["id", "name", "price", "stock"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 }

--- a/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/functions/ObjectFunctionsTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/functions/ObjectFunctionsTest.kt
@@ -1,12 +1,6 @@
 package kotlinx.schema.integration.functions
 
 import io.kotest.assertions.json.shouldEqualJson
-import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 
 /**
@@ -21,107 +15,146 @@ import kotlin.test.Test
 class ObjectFunctionsTest {
     @Test
     fun `ConfigurationManager loadConfig generates correct schema`() {
-        val schemaString = loadConfigJsonSchemaString()
-        val schema = loadConfigJsonSchema()
+        val schema = loadConfigJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-        parsed["name"]?.jsonPrimitive?.content shouldBe "loadConfig"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "configuration from a file"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["filePath"].shouldNotBeNull()
-        properties["createIfMissing"].shouldNotBeNull()
-        properties["defaults"].shouldNotBeNull()
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "loadConfig",
+              "description": "Loads configuration from a file",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "filePath": {
+                    "type": "string",
+                    "description": "Configuration file path"
+                  },
+                  "createIfMissing": {
+                    "type": "boolean",
+                    "description": "Whether to create file if it doesn't exist"
+                  },
+                  "defaults": {
+                    "type": ["object", "null"],
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Default values to use"
+                  }
+                },
+                "required": ["filePath", "createIfMissing", "defaults"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `ConfigurationManager validateConfig suspend function generates correct schema`() {
-        val schemaString = validateConfigJsonSchemaString()
-        val schema = validateConfigJsonSchema()
+        val schema = validateConfigJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-        parsed["name"]?.jsonPrimitive?.content shouldBe "validateConfig"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "asynchronously"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["config"].shouldNotBeNull()
-        properties["schemaVersion"].shouldNotBeNull()
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "validateConfig",
+              "description": "Validates configuration against schema asynchronously",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Configuration to validate"
+                  },
+                  "schemaVersion": {
+                    "type": "string",
+                    "description": "Schema version"
+                  }
+                },
+                "required": ["config", "schemaVersion"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `LogManager writeLog generates correct schema`() {
-        val schemaString = writeLogJsonSchemaString()
-        val schema = writeLogJsonSchema()
+        val schema = writeLogJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["name"]?.jsonPrimitive?.content shouldBe "writeLog"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "log entry"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["level"].shouldNotBeNull()
-        properties["message"].shouldNotBeNull()
-        properties["exception"].shouldNotBeNull()
-        properties["tags"].shouldNotBeNull()
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "writeLog",
+              "description": "Writes a log entry",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "level": {
+                    "type": "string",
+                    "description": "Log level (DEBUG, INFO, WARN, ERROR)"
+                  },
+                  "message": {
+                    "type": "string",
+                    "description": "Log message"
+                  },
+                  "exception": {
+                    "type": ["string", "null"],
+                    "description": "Optional exception details"
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Additional context tags"
+                  }
+                },
+                "required": ["level", "message", "exception", "tags"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `LogManager archiveLogs suspend function generates correct schema`() {
-        val schemaString = archiveLogsJsonSchemaString()
-        val schema = archiveLogsJsonSchema()
+        val schema = archiveLogsJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["name"]?.jsonPrimitive?.content shouldBe "archiveLogs"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "asynchronously"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["beforeTimestamp"].shouldNotBeNull()
-        properties["compressionFormat"].shouldNotBeNull()
-    }
-
-    @Test
-    fun `all object function schemas have correct structure`() {
-        val schemas = listOf(
-            loadConfigJsonSchemaString(),
-            saveConfigJsonSchemaString(),
-            validateConfigJsonSchemaString(),
-            reloadConfigurationJsonSchemaString(),
-            writeLogJsonSchemaString(),
-            flushLogsJsonSchemaString(),
-            queryLogsJsonSchemaString(),
-            archiveLogsJsonSchemaString(),
-        )
-
-        schemas.forEach { schemaString ->
-            val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-            // Verify FunctionCallingSchema structure
-            parsed["type"].shouldNotBeNull()
-            parsed["name"].shouldNotBeNull()
-            parsed["parameters"].shouldNotBeNull()
-
-            parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-
-            // Verify parameters object
-            val parameters = parsed["parameters"]?.jsonObject.shouldNotBeNull()
-            parameters["type"].shouldNotBeNull()
-            parameters["properties"].shouldNotBeNull()
-            parameters["required"].shouldNotBeNull()
-
-            parameters["type"]?.jsonPrimitive?.content shouldBe "object"
-        }
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "archiveLogs",
+              "description": "Archives old logs asynchronously",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "beforeTimestamp": {
+                    "type": "integer",
+                    "description": "Archive logs older than this timestamp"
+                  },
+                  "compressionFormat": {
+                    "type": "string",
+                    "description": "Compression format"
+                  }
+                },
+                "required": ["beforeTimestamp", "compressionFormat"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 }

--- a/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/functions/TopLevelFunctionsTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/functions/TopLevelFunctionsTest.kt
@@ -1,14 +1,6 @@
 package kotlinx.schema.integration.functions
 
 import io.kotest.assertions.json.shouldEqualJson
-import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 
 /**
@@ -24,167 +16,212 @@ import kotlin.test.Test
 class TopLevelFunctionsTest {
     @Test
     fun `greetPerson generates correct function schema`() {
-        val schemaString = greetPersonJsonSchemaString()
-        val schema = greetPersonJsonSchema()
+        val schema = greetPersonJsonSchemaString()
 
-        // Verify schema can be decoded
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        // Parse and verify structure
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        // Verify function metadata
-        parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-        parsed["name"]?.jsonPrimitive?.content shouldBe "greetPerson"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "greeting message"
-
-        // Verify parameters
-        val parameters = parsed["parameters"]?.jsonObject.shouldNotBeNull()
-        parameters["type"]?.jsonPrimitive?.content shouldBe "object"
-
-        val properties = parameters["properties"]?.jsonObject.shouldNotBeNull()
-        properties["name"].shouldNotBeNull()
-        properties["greeting"].shouldNotBeNull()
-
-        // Verify required parameters (those without defaults)
-        val required = parameters["required"]?.jsonArray.shouldNotBeNull()
-        required.map { it.jsonPrimitive.content } shouldContain "name"
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "greetPerson",
+              "description": "Sends a greeting message to a person",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the person to greet"
+                  },
+                  "greeting": {
+                    "type": "string",
+                    "description": "Optional greeting prefix (e.g., 'Hello', 'Hi')"
+                  }
+                },
+                "required": ["name", "greeting"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `calculateSum generates correct function schema`() {
-        val schemaString = calculateSumJsonSchemaString()
-        val schema = calculateSumJsonSchema()
+        val schema = calculateSumJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["name"]?.jsonPrimitive?.content shouldBe "calculateSum"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "sum of two numbers"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["a"].shouldNotBeNull()
-        properties["b"].shouldNotBeNull()
-
-        // Both parameters are required (no defaults)
-        val required = parsed["parameters"]?.jsonObject?.get("required")?.jsonArray.shouldNotBeNull()
-        required.map { it.jsonPrimitive.content } shouldContain "a"
-        required.map { it.jsonPrimitive.content } shouldContain "b"
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "calculateSum",
+              "description": "Calculates the sum of two numbers",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "a": {
+                    "type": "integer",
+                    "description": "First number"
+                  },
+                  "b": {
+                    "type": "integer",
+                    "description": "Second number"
+                  }
+                },
+                "required": ["a", "b"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `fetchUserData suspend function generates correct schema`() {
-        val schemaString = fetchUserDataJsonSchemaString()
-        val schema = fetchUserDataJsonSchema()
+        val schema = fetchUserDataJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        // Suspend functions should generate same schema as normal functions
-        parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-        parsed["name"]?.jsonPrimitive?.content shouldBe "fetchUserData"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "asynchronously"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["userId"].shouldNotBeNull()
-        properties["includeDetails"].shouldNotBeNull()
-
-        // Only userId is required (includeDetails has default)
-        val required = parsed["parameters"]?.jsonObject?.get("required")?.jsonArray.shouldNotBeNull()
-        required.map { it.jsonPrimitive.content } shouldContain "userId"
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "fetchUserData",
+              "description": "Fetches user data asynchronously from a remote service",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "integer",
+                    "description": "User ID to fetch"
+                  },
+                  "includeDetails": {
+                    "type": "boolean",
+                    "description": "Whether to include detailed profile information"
+                  }
+                },
+                "required": ["userId", "includeDetails"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `processItems suspend function generates correct schema`() {
-        val schemaString = processItemsJsonSchemaString()
-        val schema = processItemsJsonSchema()
+        val schema = processItemsJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["name"]?.jsonPrimitive?.content shouldBe "processItems"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["items"].shouldNotBeNull()
-        properties["mode"].shouldNotBeNull()
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "processItems",
+              "description": "Processes a list of items asynchronously",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "List of items to process"
+                  },
+                  "mode": {
+                    "type": "string",
+                    "description": "Processing mode"
+                  }
+                },
+                "required": ["items", "mode"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `searchProducts with nullable parameters generates correct schema`() {
-        val schemaString = searchProductsJsonSchemaString()
-        val schema = searchProductsJsonSchema()
+        val schema = searchProductsJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["name"]?.jsonPrimitive?.content shouldBe "searchProducts"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["query"].shouldNotBeNull()
-        properties["minPrice"].shouldNotBeNull()
-        properties["maxPrice"].shouldNotBeNull()
-        properties["categories"].shouldNotBeNull()
-        properties["includeOutOfStock"].shouldNotBeNull()
-
-        // Only query is required (others have defaults or are nullable)
-        val required = parsed["parameters"]?.jsonObject?.get("required")?.jsonArray.shouldNotBeNull()
-        required.map { it.jsonPrimitive.content } shouldContain "query"
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "searchProducts",
+              "description": "Searches for products with various filters",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "Search query string"
+                  },
+                  "minPrice": {
+                    "type": ["number", "null"],
+                    "description": "Minimum price filter"
+                  },
+                  "maxPrice": {
+                    "type": ["number", "null"],
+                    "description": "Maximum price filter"
+                  },
+                  "categories": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Category filters"
+                  },
+                  "includeOutOfStock": {
+                    "type": "boolean",
+                    "description": "Whether to include out-of-stock items"
+                  }
+                },
+                "required": ["query", "minPrice", "maxPrice", "categories", "includeOutOfStock"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 
     @Test
     fun `updateConfiguration suspend function with map parameter generates correct schema`() {
-        val schemaString = updateConfigurationJsonSchemaString()
-        val schema = updateConfigurationJsonSchema()
+        val schema = updateConfigurationJsonSchemaString()
 
-        schemaString shouldEqualJson Json.encodeToString(schema)
-
-        val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-        parsed["name"]?.jsonPrimitive?.content shouldBe "updateConfiguration"
-        parsed["description"]?.jsonPrimitive?.content shouldContain "configuration"
-
-        val properties = parsed["parameters"]?.jsonObject?.get("properties")?.jsonObject.shouldNotBeNull()
-        properties["key"].shouldNotBeNull()
-        properties["value"].shouldNotBeNull()
-        properties["metadata"].shouldNotBeNull()
-
-        // key and value are required, metadata is nullable
-        val required = parsed["parameters"]?.jsonObject?.get("required")?.jsonArray.shouldNotBeNull()
-        required.map { it.jsonPrimitive.content } shouldContain "key"
-        required.map { it.jsonPrimitive.content } shouldContain "value"
-    }
-
-    @Test
-    fun `all generated schemas have FunctionCallingSchema structure`() {
-        val schemas = listOf(
-            greetPersonJsonSchemaString(),
-            calculateSumJsonSchemaString(),
-            fetchUserDataJsonSchemaString(),
-            processItemsJsonSchemaString(),
-            searchProductsJsonSchemaString(),
-            updateConfigurationJsonSchemaString(),
-        )
-
-        schemas.forEach { schemaString ->
-            val parsed = Json.parseToJsonElement(schemaString).jsonObject
-
-            // All schemas should have these required fields
-            parsed["type"].shouldNotBeNull()
-            parsed["name"].shouldNotBeNull()
-            parsed["parameters"].shouldNotBeNull()
-
-            // Type should be "function"
-            parsed["type"]?.jsonPrimitive?.content shouldBe "function"
-
-            // Parameters should be an object with properties and required
-            val parameters = parsed["parameters"]?.jsonObject.shouldNotBeNull()
-            parameters["type"].shouldNotBeNull()
-            parameters["properties"].shouldNotBeNull()
-            parameters["required"].shouldNotBeNull()
-        }
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "updateConfiguration",
+              "description": "Updates configuration settings",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "description": "Configuration key"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "Configuration value"
+                  },
+                  "metadata": {
+                    "type": ["object", "null"],
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Optional metadata"
+                  }
+                },
+                "required": ["key", "value", "metadata"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
     }
 }


### PR DESCRIPTION
## Description

  - Add RequiredFieldStrategy enum (ALL_REQUIRED, NON_NULLABLE_REQUIRED, USE_DEFAULT_PRESENCE)                                                
  - Update TypeGraphToFunctionCallingSchemaTransformer with strategy parameter                                                                
  - Mark all KSP function parameters as required (strict mode compatible)                                                                     
  - Update 16 integration tests to expect OpenAI Strict Mode behavior                                                                         
  - Document strategy usage and KSP limitations in README                                                                                     
                                                                                                                                              
  Implements OpenAI Strict Mode as default while maintaining flexibility                                                                      
  for traditional JSON Schema semantics.

### What's the purpose of this PR?
To complete #44 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)
- [x] Test addition or update

## How Has This Been Tested?

**Testing checklist:**
- [x] All existing tests pass locally
- [x] Integration tests added/updated

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any commented-out code and debug statements
- [x] My code generates no new warnings or errors

### Documentation
- [x] I have updated the documentation accordingly
- [x] I have updated the README if needed
- [x] I have updated relevant comments in the code

### Testing
- [x] I have added tests that prove my fix/feature works
- [X] New and existing tests pass locally

### Dependencies & Breaking Changes
- [ ] I have checked for dependency updates
- [x] I have documented any breaking changes
- [ ] Backward compatibility is maintained (or properly documented if not)

### Focus & Scope
- [x] This PR stays focused on a single concern
- [x] I haven't included unrelated changes or "drive-by" fixes
- [x] The PR description accurately reflects ALL the changes made