### PR TITLE
chore: Bump version

### DIFF
--- a/examples/gradle-google-ksp/gradle.properties
+++ b/examples/gradle-google-ksp/gradle.properties
@@ -13,4 +13,4 @@ name = gradle-google-ksp-example
 group=org.jetbrains.kotlinx.examples
 version=1.0-SNAPSHOT
 
-kotlinxSchemaVersion=0.0.3
+kotlinxSchemaVersion=0.0.4

--- a/gradle-plugin-integration-tests/gradle.properties
+++ b/gradle-plugin-integration-tests/gradle.properties
@@ -24,4 +24,4 @@ versionSuffix=SNAPSHOT
 tzdbVersion=2025a
 defaultKotlinVersion=2.2.21
 
-kotlinxSchemaVersion=0.0.4-SNAPSHOT
+kotlinxSchemaVersion=0.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ ksp.useKSP2=true
 detekt.use.worker.api = true
 
 group=org.jetbrains.kotlinx
-version=0.0.4-SNAPSHOT
+version=0.0.5-SNAPSHOT
 
 versionSuffix=SNAPSHOT
 


### PR DESCRIPTION
# chore: Bump version

- Bump `kotlinxSchemaVersion` to 0.0.4 in examples and integration tests
- Update root project version to 0.0.5-SNAPSHOT
