### PR TITLE
fix(generator-json): Resolve sealed class name collisions using parent-qualified names (#113)

### DIFF
--- a/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectorTest.kt
+++ b/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectorTest.kt
@@ -174,20 +174,20 @@ class ReflectionIntrospectorTest {
             required shouldBe true
         }
 
-        // Ensure subtypes discovered and object nodes present
+        // Verify subtypes use qualified names (Parent.Child pattern)
         val subtypeIds = polyNode.subtypes.map { it.id.value }.toSet()
         subtypeIds.shouldContainExactlyInAnyOrder(
             setOf(
-                Shape.Circle::class.simpleName,
-                Shape.Rectangle::class.simpleName,
+                "Shape.Circle",
+                "Shape.Rectangle",
             ),
         )
 
-        // Verify each subtype has correct description
-        val circleNode = graph.nodes[TypeId("Circle")].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
+        // Verify each subtype node is registered with qualified name
+        val circleNode = graph.nodes[TypeId("Shape.Circle")].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
         circleNode.description shouldBe "Circle shape"
 
-        val rectangleNode = graph.nodes[TypeId("Rectangle")].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
+        val rectangleNode = graph.nodes[TypeId("Shape.Rectangle")].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
         rectangleNode.description shouldBe "Rectangle shape"
     }
 }

--- a/kotlinx-schema-generator-json/build.gradle.kts
+++ b/kotlinx-schema-generator-json/build.gradle.kts
@@ -19,9 +19,10 @@ kotlin {
         api(project(":kotlinx-schema-json"))
 
         // test dependencies
-        testImplementation(libs.kotlin.test)
+        testImplementation(libs.junit.pioneer)
         testImplementation(libs.kotest.assertions.core)
         testImplementation(libs.kotest.assertions.json)
+        testImplementation(libs.kotlin.test)
     }
 
     compilerOptions {

--- a/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/JsonSchemaHierarchyTest.kt
+++ b/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/JsonSchemaHierarchyTest.kt
@@ -58,27 +58,27 @@ class JsonSchemaHierarchyTest {
               "description": "Represents an animal",
               "oneOf": [
                 {
-                  "$ref": "#/$defs/Cat"
+                  "$ref": "#/$defs/Animal.Cat"
                 },
                 {
-                  "$ref": "#/$defs/Dog"
+                  "$ref": "#/$defs/Animal.Dog"
                 }
               ],
               "discriminator": {
                 "propertyName": "type",
                 "mapping": {
-                  "Cat": "#/$defs/Cat",
-                  "Dog": "#/$defs/Dog"
+                  "Cat": "#/$defs/Animal.Cat",
+                  "Dog": "#/$defs/Animal.Dog"
                 }
               },
               "$defs": {
-                "Cat": {
+                "Animal.Cat": {
                   "type": "object",
                   "description": "Represents a cat",
                   "properties": {
                     "type": {
                       "type": "string",
-                      "default": "Cat"
+                      "default": "Animal.Cat"
                     },
                     "name": {
                       "type": "string",
@@ -97,13 +97,13 @@ class JsonSchemaHierarchyTest {
                   "required": ["type", "name", "color"],
                   "additionalProperties": false
                 },
-                "Dog": {
+                "Animal.Dog": {
                   "type": "object",
                   "description": "Represents a dog",
                   "properties": {
                     "type": {
                       "type": "string",
-                      "default": "Dog"
+                      "default": "Animal.Dog"
                     },
                     "name": {
                       "type": "string",
@@ -155,17 +155,17 @@ class JsonSchemaHierarchyTest {
                     {
                       "oneOf": [
                         {
-                          "$ref": "#/$defs/Cat"
+                          "$ref": "#/$defs/Animal.Cat"
                         },
                         {
-                          "$ref": "#/$defs/Dog"
+                          "$ref": "#/$defs/Animal.Dog"
                         }
                       ],
                       "discriminator": {
                         "propertyName": "type",
                         "mapping": {
-                          "Cat": "#/$defs/Cat",
-                          "Dog": "#/$defs/Dog"
+                          "Cat": "#/$defs/Animal.Cat",
+                          "Dog": "#/$defs/Animal.Dog"
                         }
                       }
                     },
@@ -178,13 +178,13 @@ class JsonSchemaHierarchyTest {
               "required": ["animal"],
               "additionalProperties": false,
               "$defs": {
-                "Cat": {
+                "Animal.Cat": {
                   "type": "object",
                   "description": "Represents a cat",
                   "properties": {
                     "type": {
                       "type": "string",
-                      "default": "Cat"
+                      "default": "Animal.Cat"
                     },
                     "name": {
                       "type": "string",
@@ -203,13 +203,13 @@ class JsonSchemaHierarchyTest {
                   "required": ["type", "name", "color"],
                   "additionalProperties": false
                 },
-                "Dog": {
+                "Animal.Dog": {
                   "type": "object",
                   "description": "Represents a dog",
                   "properties": {
                     "type": {
                       "type": "string",
-                      "default": "Dog"
+                      "default": "Animal.Dog"
                     },
                     "name": {
                       "type": "string",

--- a/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/SealedClassNameCollisionTest.kt
+++ b/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/SealedClassNameCollisionTest.kt
@@ -1,0 +1,163 @@
+package kotlinx.schema.generator.json
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.schema.Description
+import kotlinx.schema.generator.core.SchemaGeneratorService
+import kotlinx.schema.json.JsonSchema
+import kotlinx.serialization.json.Json
+import org.junitpioneer.jupiter.Issue
+import kotlin.reflect.KClass
+import kotlin.test.Test
+
+/**
+ * Tests for handling name collisions in sealed class hierarchies.
+ *
+ * When multiple sealed classes have inner classes with the same name (e.g., "Unknown"),
+ * the generated JSON Schema definitions must use qualified names like "ParentClass.ChildClass"
+ * to avoid collisions in the $defs section.
+ */
+@Issue("https://github.com/Kotlin/kotlinx-schema/issues/113")
+class SealedClassNameCollisionTest {
+    @Description("Result type A")
+    @Suppress("unused")
+    sealed class ResultA {
+        @Description("Success result for A")
+        data class Success(
+            val value: String,
+        ) : ResultA()
+
+        @Description("Unknown error for A")
+        data class Unknown(
+            val code: Int,
+        ) : ResultA()
+    }
+
+    @Description("Result type B")
+    @Suppress("unused")
+    sealed class ResultB {
+        @Description("Success result for B")
+        data class Success(
+            val data: Int,
+        ) : ResultB()
+
+        @Description("Unknown error for B")
+        data class Unknown(
+            val message: String,
+        ) : ResultB()
+    }
+
+    @Description("Container with both result types")
+    data class ApiResponse(
+        val resultA: ResultA,
+        val resultB: ResultB,
+    )
+
+    private val generator =
+        requireNotNull(
+            SchemaGeneratorService.getGenerator(KClass::class, JsonSchema::class),
+        ) {
+            "ReflectionClassJsonSchemaGenerator must be registered"
+        }
+
+    private val json =
+        Json {
+            prettyPrint = true
+            encodeDefaults = false
+        }
+
+    @Test
+    @Suppress("LongMethod")
+    fun `Should use qualified names to avoid name collisions in sealed hierarchies`() {
+        // When - generate schema for ApiResponse which uses two sealed hierarchies
+        //        where both have "Success" and "Unknown" inner classes
+        val schema = generator.generateSchema(ApiResponse::class)
+
+        // Then - all 4 definitions should be present with qualified names
+        //       (not 2 due to collision: "Success" and "Unknown")
+        json.encodeToString(schema) shouldEqualJson
+            $$"""
+            {
+              "name": "$${ApiResponse::class.qualifiedName}",
+              "strict": false,
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "resultA": {
+                    "oneOf": [
+                      { "$ref": "#/$defs/ResultA.Success" },
+                      { "$ref": "#/$defs/ResultA.Unknown" }
+                    ],
+                    "discriminator": {
+                      "propertyName": "type",
+                      "mapping": {
+                        "Success": "#/$defs/ResultA.Success",
+                        "Unknown": "#/$defs/ResultA.Unknown"
+                      }
+                    },
+                    "description": "Result type A"
+                  },
+                  "resultB": {
+                    "oneOf": [
+                      { "$ref": "#/$defs/ResultB.Success" },
+                      { "$ref": "#/$defs/ResultB.Unknown" }
+                    ],
+                    "discriminator": {
+                      "propertyName": "type",
+                      "mapping": {
+                        "Success": "#/$defs/ResultB.Success",
+                        "Unknown": "#/$defs/ResultB.Unknown"
+                      }
+                    },
+                    "description": "Result type B"
+                  }
+                },
+                "required": ["resultA", "resultB"],
+                "additionalProperties": false,
+                "description": "Container with both result types",
+                "$defs": {
+                  "ResultA.Success": {
+                    "type": "object",
+                    "description": "Success result for A",
+                    "properties": {
+                      "type": { "type": "string", "default": "ResultA.Success" },
+                      "value": { "type": "string" }
+                    },
+                    "required": ["type", "value"],
+                    "additionalProperties": false
+                  },
+                  "ResultA.Unknown": {
+                    "type": "object",
+                    "description": "Unknown error for A",
+                    "properties": {
+                      "type": { "type": "string", "default": "ResultA.Unknown" },
+                      "code": { "type": "integer" }
+                    },
+                    "required": ["type", "code"],
+                    "additionalProperties": false
+                  },
+                  "ResultB.Success": {
+                    "type": "object",
+                    "description": "Success result for B",
+                    "properties": {
+                      "type": { "type": "string", "default": "ResultB.Success" },
+                      "data": { "type": "integer" }
+                    },
+                    "required": ["type", "data"],
+                    "additionalProperties": false
+                  },
+                  "ResultB.Unknown": {
+                    "type": "object",
+                    "description": "Unknown error for B",
+                    "properties": {
+                      "type": { "type": "string", "default": "ResultB.Unknown" },
+                      "message": { "type": "string" }
+                    },
+                    "required": ["type", "message"],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}

--- a/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/SealedHierarchyTest.kt
+++ b/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/SealedHierarchyTest.kt
@@ -10,12 +10,10 @@ class SealedHierarchyTest {
         val json =
             Json {
                 encodeDefaults = false
-                prettyPrint = true
             }
         val schema =
             ReflectionClassJsonSchemaGenerator(
-                json =
-                json,
+                json = json,
                 config = JsonSchemaConfig.Strict,
             ).generateSchema(ExampleA::class)
         val actual = json.encodeToString(schema)
@@ -31,15 +29,15 @@ class SealedHierarchyTest {
                    "additionalProperties": false,
                    "oneOf": [
                      {
-                       "$ref": "#/$defs/ExampleB"
+                       "$ref": "#/$defs/ExampleA.ExampleB"
                      }
                    ],
                    "$defs": {
-                     "ExampleB": {
+                     "ExampleA.ExampleB": {
                        "type": "object",
                        "properties": {
                          "type": {
-                           "const": "ExampleB",
+                           "const": "ExampleA.ExampleB",
                            "type": "string"
                          },
                          "someProp": {

--- a/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonObjectSchemaTransformerTest.kt
+++ b/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonObjectSchemaTransformerTest.kt
@@ -68,9 +68,9 @@ class TypeGraphToJsonObjectSchemaTransformerTest {
         val animalDef = defs["kotlinx.schema.generator.json.JsonSchemaHierarchyTest.Animal"] as JsonObject
         val oneOf = animalDef["oneOf"] as JsonArray
         oneOf.size shouldBe 2
-        // Subtype IDs are simple names in this case
+        // Subtype IDs use qualified names (Parent.Child) to avoid collisions
         val refs = oneOf.map { (it as JsonObject)[$$"$ref"].toString() }.sorted()
-        refs.shouldBe(listOf($$"\"#/$defs/Cat\"", $$"\"#/$defs/Dog\""))
+        refs.shouldBe(listOf($$"\"#/$defs/Animal.Cat\"", $$"\"#/$defs/Animal.Dog\""))
     }
 
     data class SimplePerson(

--- a/kotlinx-schema-json/src/commonTest/kotlin/kotlinx/schema/json/JsonSchemaSerializationTest.kt
+++ b/kotlinx-schema-json/src/commonTest/kotlin/kotlinx/schema/json/JsonSchemaSerializationTest.kt
@@ -86,11 +86,10 @@ internal class JsonSchemaSerializationTest {
     fun `Should de-serialize Schema with id and schema`() {
         // language=json
         val json =
-            """
+            $$"""
             {
-            
-                "${'$'}schema": "https://json-schema.org/draft-07/schema", 
-                "${'$'}id": "https://example.com/schemas/product", 
+                "$schema": "https://json-schema.org/draft-07/schema", 
+                "$id": "https://example.com/schemas/product", 
                 "type" : "object",
                 "properties" : {
                   "name" : {
@@ -124,7 +123,7 @@ internal class JsonSchemaSerializationTest {
     fun `Should deserialize complex JsonSchema`() {
         // language=json
         val json =
-            """
+            $$"""
             {
               "name": "ComplexSchema",
               "strict": true,
@@ -223,7 +222,7 @@ internal class JsonSchemaSerializationTest {
                     "const": false
                   },
                   "reference": {
-                    "${'$'}ref": "#/definitions/ExternalType"
+                    "$ref": "#/definitions/ExternalType"
                   }
                 },
                 "required": ["id", "email", "status"],
@@ -265,7 +264,7 @@ internal class JsonSchemaSerializationTest {
             type shouldBe listOf("string")
             nullable shouldBe null
             format shouldBe "email"
-            pattern shouldBe "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+\$"
+            pattern shouldBe $$"^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$"
             description shouldBe "Email address"
             minLength shouldBe 5
             maxLength shouldBe 100
@@ -404,7 +403,7 @@ internal class JsonSchemaSerializationTest {
     fun `Should serialize and deserialize polymorphic schema with defs and ref`() {
         // language=json
         val json =
-            """
+            $$"""
             {
               "name": "Animal",
               "strict": false,
@@ -414,20 +413,20 @@ internal class JsonSchemaSerializationTest {
                 "description": "Animal hierarchy",
                 "oneOf": [
                   {
-                    "${'$'}ref": "#/${'$'}defs/Cat"
+                    "$ref": "#/$defs/Cat"
                   },
                   {
-                    "${'$'}ref": "#/${'$'}defs/Dog"
+                    "$ref": "#/$defs/Dog"
                   }
                 ],
                 "discriminator": {
                   "propertyName": "type",
                   "mapping": {
-                    "Cat": "#/${'$'}defs/Cat",
-                    "Dog": "#/${'$'}defs/Dog"
+                    "Cat": "#/$defs/Cat",
+                    "Dog": "#/$defs/Dog"
                   }
                 },
-                "${'$'}defs": {
+                "$defs": {
                   "Cat": {
                     "type": "object",
                     "description": "A cat",
@@ -476,11 +475,11 @@ internal class JsonSchemaSerializationTest {
             shouldHaveSize(2)
             this[0] shouldNotBeNull {
                 this as ReferencePropertyDefinition
-                ref shouldBe "#/\$defs/Cat"
+                ref shouldBe $$"#/$defs/Cat"
             }
             this[1] shouldNotBeNull {
                 this as ReferencePropertyDefinition
-                ref shouldBe "#/\$defs/Dog"
+                ref shouldBe $$"#/$defs/Dog"
             }
         }
 
@@ -489,8 +488,8 @@ internal class JsonSchemaSerializationTest {
             propertyName shouldBe "type"
             mapping shouldNotBeNull {
                 shouldHaveSize(2)
-                this["Cat"] shouldBe "#/\$defs/Cat"
-                this["Dog"] shouldBe "#/\$defs/Dog"
+                this["Cat"] shouldBe $$"#/$defs/Cat"
+                this["Dog"] shouldBe $$"#/$defs/Dog"
             }
         }
 
@@ -538,7 +537,7 @@ internal class JsonSchemaSerializationTest {
     fun `Should serialize and deserialize nullable polymorphic schema with anyOf`() {
         // language=json
         val json =
-            """
+            $$"""
             {
               "name": "Container",
               "strict": false,
@@ -551,17 +550,17 @@ internal class JsonSchemaSerializationTest {
                       {
                         "oneOf": [
                           {
-                            "${'$'}ref": "#/${'$'}defs/Cat"
+                            "$ref": "#/$defs/Cat"
                           },
                           {
-                            "${'$'}ref": "#/${'$'}defs/Dog"
+                            "$ref": "#/$defs/Dog"
                           }
                         ],
                         "discriminator": {
                           "propertyName": "type",
                           "mapping": {
-                            "Cat": "#/${'$'}defs/Cat",
-                            "Dog": "#/${'$'}defs/Dog"
+                            "Cat": "#/$defs/Cat",
+                            "Dog": "#/$defs/Dog"
                           }
                         }
                       },
@@ -573,7 +572,7 @@ internal class JsonSchemaSerializationTest {
                 },
                 "required": ["animal"],
                 "additionalProperties": false,
-                "${'$'}defs": {
+                "$defs": {
                   "Cat": {
                     "type": "object",
                     "properties": {
@@ -616,7 +615,7 @@ internal class JsonSchemaSerializationTest {
                 oneOf shouldHaveSize 2
                 oneOf[0] shouldNotBeNull {
                     this as ReferencePropertyDefinition
-                    ref shouldBe "#/\$defs/Cat"
+                    ref shouldBe $$"#/$defs/Cat"
                 }
                 discriminator shouldNotBeNull {
                     propertyName shouldBe "type"


### PR DESCRIPTION
## Description

fix(generator-json): Resolve sealed class name collisions using parent-qualified names (#113)

- Updated JSON Schema generation for sealed subclasses to use qualified names to avoid definition collisions.
- Refactored handling of sealed hierarchies to include parent prefixes in type identifiers.
- Adjusted tests and expected outputs to verify changes.
- Improved schema generation consistency for complex nested structures.

**Related Issues:** Fixes #113

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [ ] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements
