### PR TITLE
refactor(schema): Use JsonSchemaConstants

### DIFF
--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/Config.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/Config.kt
@@ -1,5 +1,6 @@
 package kotlinx.schema.generator.core
 
+import kotlinx.schema.generator.core.Config.descriptionAnnotationNames
 import java.io.IOException
 import java.util.Properties
 

--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/ir/Introspections.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/ir/Introspections.kt
@@ -1,6 +1,9 @@
 package kotlinx.schema.generator.core.ir
 
 import kotlinx.schema.generator.core.Config
+import kotlinx.schema.generator.core.ir.Introspections.descriptionAnnotationNames
+import kotlinx.schema.generator.core.ir.Introspections.descriptionValueAttributes
+import kotlinx.schema.generator.core.ir.Introspections.getDescriptionFromAnnotation
 
 /**
  * Utility object for annotation-based introspection, providing methods to process annotations,

--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/reflect/ReflectionFunctionIntrospector.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/reflect/ReflectionFunctionIntrospector.kt
@@ -1,6 +1,5 @@
 package kotlinx.schema.generator.reflect
 import kotlinx.schema.generator.core.ir.ObjectNode
-import kotlinx.schema.generator.core.ir.PrimitiveNode
 import kotlinx.schema.generator.core.ir.Property
 import kotlinx.schema.generator.core.ir.SchemaIntrospector
 import kotlinx.schema.generator.core.ir.TypeGraph
@@ -9,7 +8,6 @@ import kotlinx.schema.generator.core.ir.TypeRef
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
-import kotlin.reflect.KProperty1
 
 /**
  * Introspects Kotlin functions/methods using reflection to build a [TypeGraph].

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToFunctionCallingSchemaTransformer.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToFunctionCallingSchemaTransformer.kt
@@ -13,6 +13,18 @@ import kotlinx.schema.generator.core.ir.TypeRef
 import kotlinx.schema.json.ArrayPropertyDefinition
 import kotlinx.schema.json.BooleanPropertyDefinition
 import kotlinx.schema.json.FunctionCallingSchema
+import kotlinx.schema.json.JsonSchemaConstants.Types.ARRAY_OR_NULL_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.ARRAY_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.BOOLEAN_OR_NULL_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.BOOLEAN_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.INTEGER_OR_NULL_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.INTEGER_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.NUMBER_OR_NULL_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.NUMBER_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.OBJECT_OR_NULL_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.OBJECT_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.STRING_OR_NULL_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.STRING_TYPE
 import kotlinx.schema.json.NumericPropertyDefinition
 import kotlinx.schema.json.ObjectPropertyDefinition
 import kotlinx.schema.json.PropertyDefinition
@@ -197,7 +209,7 @@ public class TypeGraphToFunctionCallingSchemaTransformer
             when (node.kind) {
                 PrimitiveKind.STRING -> {
                     StringPropertyDefinition(
-                        type = if (nullable) listOf("string", "null") else listOf("string"),
+                        type = if (nullable) STRING_OR_NULL_TYPE else STRING_TYPE,
                         description = node.description,
                         nullable = null,
                     )
@@ -205,23 +217,15 @@ public class TypeGraphToFunctionCallingSchemaTransformer
 
                 PrimitiveKind.BOOLEAN -> {
                     BooleanPropertyDefinition(
-                        type = if (nullable) listOf("boolean", "null") else listOf("boolean"),
+                        type = if (nullable) BOOLEAN_OR_NULL_TYPE else BOOLEAN_TYPE,
                         description = node.description,
                         nullable = null,
                     )
                 }
 
-                PrimitiveKind.INT -> {
+                PrimitiveKind.INT, PrimitiveKind.LONG -> {
                     NumericPropertyDefinition(
-                        type = if (nullable) listOf("integer", "null") else listOf("integer"),
-                        description = node.description,
-                        nullable = null,
-                    )
-                }
-
-                PrimitiveKind.LONG -> {
-                    NumericPropertyDefinition(
-                        type = if (nullable) listOf("integer", "null") else listOf("integer"),
+                        type = if (nullable) INTEGER_OR_NULL_TYPE else INTEGER_TYPE,
                         description = node.description,
                         nullable = null,
                     )
@@ -229,7 +233,7 @@ public class TypeGraphToFunctionCallingSchemaTransformer
 
                 PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> {
                     NumericPropertyDefinition(
-                        type = if (nullable) listOf("number", "null") else listOf("number"),
+                        type = if (nullable) NUMBER_OR_NULL_TYPE else NUMBER_TYPE,
                         description = node.description,
                         nullable = null,
                     )
@@ -267,7 +271,7 @@ public class TypeGraphToFunctionCallingSchemaTransformer
                 }
 
             return ObjectPropertyDefinition(
-                type = if (nullable) listOf("object", "null") else listOf("object"),
+                type = if (nullable) OBJECT_OR_NULL_TYPE else OBJECT_TYPE,
                 description = node.description,
                 nullable = null,
                 properties = properties,
@@ -281,7 +285,7 @@ public class TypeGraphToFunctionCallingSchemaTransformer
             nullable: Boolean,
         ): PropertyDefinition =
             StringPropertyDefinition(
-                type = if (nullable) listOf("string", "null") else listOf("string"),
+                type = if (nullable) STRING_OR_NULL_TYPE else STRING_TYPE,
                 description = node.description,
                 nullable = null,
                 enum = node.entries,
@@ -294,7 +298,7 @@ public class TypeGraphToFunctionCallingSchemaTransformer
         ): PropertyDefinition {
             val items = convertTypeRef(node.element, graph)
             return ArrayPropertyDefinition(
-                type = if (nullable) listOf("array", "null") else listOf("array"),
+                type = if (nullable) ARRAY_OR_NULL_TYPE else ARRAY_TYPE,
                 description = node.description,
                 nullable = null,
                 items = items,
@@ -310,7 +314,7 @@ public class TypeGraphToFunctionCallingSchemaTransformer
             val additionalPropertiesSchema = json.encodeToJsonElement(valuePropertyDef)
 
             return ObjectPropertyDefinition(
-                type = if (nullable) listOf("object", "null") else listOf("object"),
+                type = if (nullable) OBJECT_OR_NULL_TYPE else OBJECT_TYPE,
                 description = node.description,
                 nullable = null,
                 additionalProperties = additionalPropertiesSchema,

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonObjectSchemaTransformer.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonObjectSchemaTransformer.kt
@@ -12,7 +12,7 @@ import kotlinx.schema.generator.core.ir.TypeGraph
 import kotlinx.schema.generator.core.ir.TypeId
 import kotlinx.schema.generator.core.ir.TypeNode
 import kotlinx.schema.generator.core.ir.TypeRef
-import kotlinx.schema.generator.json.internal.JsonSchemaConsts
+import kotlinx.schema.json.JsonSchemaConstants
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -36,13 +36,20 @@ public class TypeGraphToJsonObjectSchemaTransformer :
         // Helpers for nullability
         fun JsonObject.withNullableTypeUnion(): JsonObject {
             val m = this.toMutableMap()
-            val t = m[JsonSchemaConsts.Keys.TYPE]
+            val t = m[JsonSchemaConstants.Keys.TYPE]
             if (t is JsonPrimitive) {
-                m[JsonSchemaConsts.Keys.TYPE] = JsonArray(listOf(t, JsonPrimitive(JsonSchemaConsts.Types.NULL)))
-            } else if (m.containsKey(JsonSchemaConsts.Keys.ONE_OF)) {
-                val arr = (m[JsonSchemaConsts.Keys.ONE_OF] as? JsonArray)?.toMutableList() ?: mutableListOf()
-                arr.add(buildJsonObject { put(JsonSchemaConsts.Keys.TYPE, JsonPrimitive(JsonSchemaConsts.Types.NULL)) })
-                m[JsonSchemaConsts.Keys.ONE_OF] = JsonArray(arr)
+                m[JsonSchemaConstants.Keys.TYPE] = JsonArray(listOf(t, JsonPrimitive(JsonSchemaConstants.Types.NULL)))
+            } else if (m.containsKey(JsonSchemaConstants.Keys.ONE_OF)) {
+                val arr = (m[JsonSchemaConstants.Keys.ONE_OF] as? JsonArray)?.toMutableList() ?: mutableListOf()
+                arr.add(
+                    buildJsonObject {
+                        put(
+                            JsonSchemaConstants.Keys.TYPE,
+                            JsonPrimitive(JsonSchemaConstants.Types.NULL),
+                        )
+                    },
+                )
+                m[JsonSchemaConstants.Keys.ONE_OF] = JsonArray(arr)
             }
             return JsonObject(m)
         }
@@ -90,30 +97,30 @@ public class TypeGraphToJsonObjectSchemaTransformer :
                 is PrimitiveNode -> {
                     buildJsonObject {
                         put(
-                            JsonSchemaConsts.Keys.TYPE,
+                            JsonSchemaConstants.Keys.TYPE,
                             when (node.kind) {
-                                PrimitiveKind.STRING -> JsonSchemaConsts.Types.STRING
-                                PrimitiveKind.BOOLEAN -> JsonSchemaConsts.Types.BOOLEAN
-                                PrimitiveKind.INT -> JsonSchemaConsts.Types.INTEGER
-                                PrimitiveKind.LONG -> JsonSchemaConsts.Types.INTEGER
-                                PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> JsonSchemaConsts.Types.NUMBER
+                                PrimitiveKind.STRING -> JsonSchemaConstants.Types.STRING
+                                PrimitiveKind.BOOLEAN -> JsonSchemaConstants.Types.BOOLEAN
+                                PrimitiveKind.INT -> JsonSchemaConstants.Types.INTEGER
+                                PrimitiveKind.LONG -> JsonSchemaConstants.Types.INTEGER
+                                PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> JsonSchemaConstants.Types.NUMBER
                             },
                         )
-                        node.description?.let { put(JsonSchemaConsts.Keys.DESCRIPTION, it) }
+                        node.description?.let { put(JsonSchemaConstants.Keys.DESCRIPTION, it) }
                     }
                 }
 
                 is EnumNode -> {
                     buildJsonObject {
-                        put(JsonSchemaConsts.Keys.TYPE, JsonSchemaConsts.Types.STRING)
-                        put(JsonSchemaConsts.Keys.ENUM, JsonArray(node.entries.map { JsonPrimitive(it) }))
-                        node.description?.let { put(JsonSchemaConsts.Keys.DESCRIPTION, it) }
+                        put(JsonSchemaConstants.Keys.TYPE, JsonSchemaConstants.Types.STRING)
+                        put(JsonSchemaConstants.Keys.ENUM, JsonArray(node.entries.map { JsonPrimitive(it) }))
+                        node.description?.let { put(JsonSchemaConstants.Keys.DESCRIPTION, it) }
                     }
                 }
 
                 is ObjectNode -> {
                     buildJsonObject {
-                        put(JsonSchemaConsts.Keys.TYPE, JsonSchemaConsts.Types.OBJECT)
+                        put(JsonSchemaConstants.Keys.TYPE, JsonSchemaConstants.Types.OBJECT)
                         val props =
                             buildJsonObject {
                                 for (p in node.properties) {
@@ -123,7 +130,7 @@ public class TypeGraphToJsonObjectSchemaTransformer :
                                     val merged =
                                         if (p.description != null) {
                                             val m = base.toMutableMap()
-                                            m[JsonSchemaConsts.Keys.DESCRIPTION] = JsonPrimitive(p.description)
+                                            m[JsonSchemaConstants.Keys.DESCRIPTION] = JsonPrimitive(p.description)
                                             JsonObject(m)
                                         } else {
                                             base
@@ -131,47 +138,47 @@ public class TypeGraphToJsonObjectSchemaTransformer :
                                     put(p.name, merged)
                                 }
                             }
-                        put(JsonSchemaConsts.Keys.PROPERTIES, props)
-                        put(JsonSchemaConsts.Keys.REQUIRED, JsonArray(node.required.map { JsonPrimitive(it) }))
-                        put(JsonSchemaConsts.Keys.ADDITIONAL_PROPERTIES, JsonPrimitive(false))
-                        node.description?.let { put(JsonSchemaConsts.Keys.DESCRIPTION, it) }
+                        put(JsonSchemaConstants.Keys.PROPERTIES, props)
+                        put(JsonSchemaConstants.Keys.REQUIRED, JsonArray(node.required.map { JsonPrimitive(it) }))
+                        put(JsonSchemaConstants.Keys.ADDITIONAL_PROPERTIES, JsonPrimitive(false))
+                        node.description?.let { put(JsonSchemaConstants.Keys.DESCRIPTION, it) }
                     }
                 }
 
                 is ListNode -> {
                     buildJsonObject {
-                        put(JsonSchemaConsts.Keys.TYPE, JsonSchemaConsts.Types.ARRAY)
-                        put(JsonSchemaConsts.Keys.ITEMS, emitRef(node.element))
-                        node.description?.let { put(JsonSchemaConsts.Keys.DESCRIPTION, it) }
+                        put(JsonSchemaConstants.Keys.TYPE, JsonSchemaConstants.Types.ARRAY)
+                        put(JsonSchemaConstants.Keys.ITEMS, emitRef(node.element))
+                        node.description?.let { put(JsonSchemaConstants.Keys.DESCRIPTION, it) }
                     }
                 }
 
                 is MapNode -> {
                     buildJsonObject {
-                        put(JsonSchemaConsts.Keys.TYPE, JsonSchemaConsts.Types.OBJECT)
-                        put(JsonSchemaConsts.Keys.ADDITIONAL_PROPERTIES, emitRef(node.value))
-                        node.description?.let { put(JsonSchemaConsts.Keys.DESCRIPTION, it) }
+                        put(JsonSchemaConstants.Keys.TYPE, JsonSchemaConstants.Types.OBJECT)
+                        put(JsonSchemaConstants.Keys.ADDITIONAL_PROPERTIES, emitRef(node.value))
+                        node.description?.let { put(JsonSchemaConstants.Keys.DESCRIPTION, it) }
                     }
                 }
 
                 is PolymorphicNode -> {
                     buildJsonObject {
                         put(
-                            JsonSchemaConsts.Keys.ONE_OF,
+                            JsonSchemaConstants.Keys.ONE_OF,
                             buildJsonArray {
                                 node.subtypes.forEach { st ->
                                     add(
                                         buildJsonObject {
                                             put(
-                                                JsonSchemaConsts.Keys.REF,
-                                                "${JsonSchemaConsts.Keys.REF_PREFIX}${st.id}",
+                                                JsonSchemaConstants.Keys.REF,
+                                                "${JsonSchemaConstants.Keys.REF_PREFIX}${st.id}",
                                             )
                                         },
                                     )
                                 }
                             },
                         )
-                        node.description?.let { put(JsonSchemaConsts.Keys.DESCRIPTION, it) }
+                        node.description?.let { put(JsonSchemaConstants.Keys.DESCRIPTION, it) }
                     }
                 }
             }
@@ -183,21 +190,21 @@ public class TypeGraphToJsonObjectSchemaTransformer :
                     if (ref.nullable) {
                         buildJsonObject {
                             put(
-                                JsonSchemaConsts.Keys.ONE_OF,
+                                JsonSchemaConstants.Keys.ONE_OF,
                                 buildJsonArray {
                                     add(
                                         buildJsonObject {
                                             put(
-                                                JsonSchemaConsts.Keys.REF,
-                                                "${JsonSchemaConsts.Keys.REF_PREFIX}${ref.id}",
+                                                JsonSchemaConstants.Keys.REF,
+                                                "${JsonSchemaConstants.Keys.REF_PREFIX}${ref.id}",
                                             )
                                         },
                                     )
                                     add(
                                         buildJsonObject {
                                             put(
-                                                JsonSchemaConsts.Keys.TYPE,
-                                                JsonPrimitive(JsonSchemaConsts.Types.NULL),
+                                                JsonSchemaConstants.Keys.TYPE,
+                                                JsonPrimitive(JsonSchemaConstants.Types.NULL),
                                             )
                                         },
                                     )
@@ -207,8 +214,8 @@ public class TypeGraphToJsonObjectSchemaTransformer :
                     } else {
                         buildJsonObject {
                             put(
-                                JsonSchemaConsts.Keys.REF,
-                                "${JsonSchemaConsts.Keys.REF_PREFIX}${ref.id}",
+                                JsonSchemaConstants.Keys.REF,
+                                "${JsonSchemaConstants.Keys.REF_PREFIX}${ref.id}",
                             )
                         }
                     }
@@ -242,14 +249,14 @@ public class TypeGraphToJsonObjectSchemaTransformer :
                             if (ref.nullable) {
                                 buildJsonObject {
                                     put(
-                                        JsonSchemaConsts.Keys.ONE_OF,
+                                        JsonSchemaConstants.Keys.ONE_OF,
                                         buildJsonArray {
                                             add(base)
                                             add(
                                                 buildJsonObject {
                                                     put(
-                                                        JsonSchemaConsts.Keys.TYPE,
-                                                        JsonPrimitive(JsonSchemaConsts.Types.NULL),
+                                                        JsonSchemaConstants.Keys.TYPE,
+                                                        JsonPrimitive(JsonSchemaConstants.Types.NULL),
                                                     )
                                                 },
                                             )
@@ -279,15 +286,16 @@ public class TypeGraphToJsonObjectSchemaTransformer :
                     val existing = defs[key] ?: return@forEach
                     val schema = existing.toMutableMap()
                     val props =
-                        (schema[JsonSchemaConsts.Keys.PROPERTIES] as? JsonObject)?.toMutableMap() ?: mutableMapOf()
-                    props[disc.name] = buildJsonObject { put(JsonSchemaConsts.Keys.CONST, JsonPrimitive(st.id.value)) }
-                    schema[JsonSchemaConsts.Keys.PROPERTIES] = JsonObject(props)
+                        (schema[JsonSchemaConstants.Keys.PROPERTIES] as? JsonObject)?.toMutableMap() ?: mutableMapOf()
+                    props[disc.name] =
+                        buildJsonObject { put(JsonSchemaConstants.Keys.CONST, JsonPrimitive(st.id.value)) }
+                    schema[JsonSchemaConstants.Keys.PROPERTIES] = JsonObject(props)
                     val required =
-                        (schema[JsonSchemaConsts.Keys.REQUIRED] as? JsonArray)?.toMutableList() ?: mutableListOf()
+                        (schema[JsonSchemaConstants.Keys.REQUIRED] as? JsonArray)?.toMutableList() ?: mutableListOf()
                     if (required.none { it is JsonPrimitive && it.content == disc.name }) {
                         required.add(JsonPrimitive(disc.name))
                     }
-                    schema[JsonSchemaConsts.Keys.REQUIRED] = JsonArray(required)
+                    schema[JsonSchemaConstants.Keys.REQUIRED] = JsonArray(required)
                     defs[key] = JsonObject(schema)
                 }
             }
@@ -295,8 +303,8 @@ public class TypeGraphToJsonObjectSchemaTransformer :
 
         val rootSchema = emitRef(graph.root)
         return buildJsonObject {
-            put(JsonSchemaConsts.Keys.ID, rootName)
-            if (defs.isNotEmpty()) put(JsonSchemaConsts.Keys.DEFS, JsonObject(defs))
+            put(JsonSchemaConstants.Keys.ID, rootName)
+            if (defs.isNotEmpty()) put(JsonSchemaConstants.Keys.DEFS, JsonObject(defs))
             rootSchema.entries.forEach { entry -> put(entry.key, entry.value) }
         }
     }

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonSchemaTransformer.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonSchemaTransformer.kt
@@ -16,6 +16,9 @@ import kotlinx.schema.json.ArrayPropertyDefinition
 import kotlinx.schema.json.BooleanPropertyDefinition
 import kotlinx.schema.json.Discriminator
 import kotlinx.schema.json.JsonSchema
+import kotlinx.schema.json.JsonSchemaConstants.Types.INTEGER_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.NULL_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.NUMBER_TYPE
 import kotlinx.schema.json.JsonSchemaDefinition
 import kotlinx.schema.json.NumericPropertyDefinition
 import kotlinx.schema.json.ObjectPropertyDefinition
@@ -230,7 +233,6 @@ public class TypeGraphToJsonSchemaTransformer
             when (node.kind) {
                 PrimitiveKind.STRING -> {
                     StringPropertyDefinition(
-                        type = listOf("string"),
                         description = null,
                         nullable = if (nullable) true else null,
                     )
@@ -238,23 +240,14 @@ public class TypeGraphToJsonSchemaTransformer
 
                 PrimitiveKind.BOOLEAN -> {
                     BooleanPropertyDefinition(
-                        type = listOf("boolean"),
                         description = null,
                         nullable = if (nullable) true else null,
                     )
                 }
 
-                PrimitiveKind.INT -> {
+                PrimitiveKind.INT, PrimitiveKind.LONG -> {
                     NumericPropertyDefinition(
-                        type = listOf("integer"),
-                        description = null,
-                        nullable = if (nullable) true else null,
-                    )
-                }
-
-                PrimitiveKind.LONG -> {
-                    NumericPropertyDefinition(
-                        type = listOf("integer"),
+                        type = INTEGER_TYPE,
                         description = null,
                         nullable = if (nullable) true else null,
                     )
@@ -262,7 +255,7 @@ public class TypeGraphToJsonSchemaTransformer
 
                 PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> {
                     NumericPropertyDefinition(
-                        type = listOf("number"),
+                        type = NUMBER_TYPE,
                         description = null,
                         nullable = if (nullable) true else null,
                     )
@@ -343,7 +336,6 @@ public class TypeGraphToJsonSchemaTransformer
                 }
 
             return ObjectPropertyDefinition(
-                type = listOf("object"),
                 description = node.description,
                 nullable = if (nullable) true else null,
                 properties = properties,
@@ -357,7 +349,6 @@ public class TypeGraphToJsonSchemaTransformer
             nullable: Boolean,
         ): PropertyDefinition =
             StringPropertyDefinition(
-                type = listOf("string"),
                 description = node.description,
                 nullable = if (nullable) true else null,
                 enum = node.entries,
@@ -371,7 +362,6 @@ public class TypeGraphToJsonSchemaTransformer
         ): PropertyDefinition {
             val items = convertTypeRef(node.element, graph, definitions)
             return ArrayPropertyDefinition(
-                type = listOf("array"),
                 description = null,
                 nullable = if (nullable) true else null,
                 items = items,
@@ -390,7 +380,6 @@ public class TypeGraphToJsonSchemaTransformer
             val additionalPropertiesSchema = json.encodeToJsonElement(valuePropertyDef)
 
             return ObjectPropertyDefinition(
-                type = listOf("object"),
                 description = null,
                 nullable = if (nullable) true else null,
                 additionalProperties = additionalPropertiesSchema,
@@ -456,7 +445,7 @@ public class TypeGraphToJsonSchemaTransformer
                         listOf(
                             oneOfDef,
                             StringPropertyDefinition(
-                                type = listOf("null"),
+                                type = NULL_TYPE,
                                 description = null,
                                 nullable = null,
                             ),

--- a/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchema.dsl.kt
+++ b/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchema.dsl.kt
@@ -2,6 +2,13 @@
 
 package kotlinx.schema.json
 
+import kotlinx.schema.json.JsonSchemaConstants.Keys.TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.ARRAY_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.BOOLEAN_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.INTEGER
+import kotlinx.schema.json.JsonSchemaConstants.Types.NUMBER
+import kotlinx.schema.json.JsonSchemaConstants.Types.OBJECT_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.STRING_TYPE
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -720,7 +727,7 @@ public class StringPropertyBuilder internal constructor() {
     /**
      * The JSON Schema type. Always ["string"] for this builder.
      */
-    public var type: List<String> = listOf("string")
+    public var type: List<String> = STRING_TYPE
 
     /**
      * Human-readable description of this property.
@@ -967,7 +974,7 @@ public class StringPropertyBuilder internal constructor() {
  */
 @JsonSchemaDsl
 public class NumericPropertyBuilder internal constructor(
-    type: String = "number",
+    type: String = NUMBER,
 ) {
     /**
      * The JSON Schema type. Either ["integer"] or ["number"].
@@ -1188,7 +1195,7 @@ public class BooleanPropertyBuilder internal constructor() {
     /**
      * The JSON Schema type. Always ["boolean"] for this builder.
      */
-    public var type: List<String> = listOf("boolean")
+    public var type: List<String> = BOOLEAN_TYPE
 
     /**
      * Human-readable description of this property.
@@ -1353,7 +1360,7 @@ public class BooleanPropertyBuilder internal constructor() {
  * - Heterogeneous enums
  *
  * This class is part of the JSON Schema DSL and cannot be instantiated directly.
- * Use [SchemaBuilder.generic] to create instances.
+ * Use [JsonSchemaDefinitionBuilder.property] to create instances.
  *
  * ## Example
  * ```kotlin
@@ -1604,7 +1611,7 @@ public class ArrayPropertyBuilder internal constructor() {
     /**
      * The JSON Schema type. Always ["array"] for this builder.
      */
-    public var type: List<String> = listOf("array")
+    public var type: List<String> = ARRAY_TYPE
 
     /**
      * Human-readable description of this property.
@@ -1798,14 +1805,14 @@ public class ArrayPropertyBuilder internal constructor() {
      * Specifies that array items are integers.
      */
     public fun ofInteger(block: NumericPropertyBuilder.() -> Unit = {}) {
-        itemsDefinition = NumericPropertyBuilder(type = "integer").apply(block).build()
+        itemsDefinition = NumericPropertyBuilder(type = INTEGER).apply(block).build()
     }
 
     /**
      * Specifies that array items are numbers (supports decimals).
      */
     public fun ofNumber(block: NumericPropertyBuilder.() -> Unit = {}) {
-        itemsDefinition = NumericPropertyBuilder(type = "number").apply(block).build()
+        itemsDefinition = NumericPropertyBuilder(type = NUMBER).apply(block).build()
     }
 
     /**
@@ -1912,7 +1919,7 @@ public class ObjectPropertyBuilder internal constructor() {
     /**
      * The JSON Schema type. Always ["object"] for this builder.
      */
-    public var type: List<String> = listOf("object")
+    public var type: List<String> = OBJECT_TYPE
 
     /**
      * Human-readable description of this property.
@@ -2184,12 +2191,12 @@ public fun PolymorphicOptionsCollector.string(block: StringPropertyBuilder.() ->
 
 /** Adds an integer schema option. */
 public fun PolymorphicOptionsCollector.integer(block: NumericPropertyBuilder.() -> Unit = {}) {
-    addOption(NumericPropertyBuilder(type = "integer").apply(block).build())
+    addOption(NumericPropertyBuilder(type = INTEGER).apply(block).build())
 }
 
 /** Adds a number schema option. */
 public fun PolymorphicOptionsCollector.number(block: NumericPropertyBuilder.() -> Unit = {}) {
-    addOption(NumericPropertyBuilder(type = "number").apply(block).build())
+    addOption(NumericPropertyBuilder(type = NUMBER).apply(block).build())
 }
 
 /** Adds a boolean schema option. */
@@ -2380,7 +2387,7 @@ public class OneOfPropertyBuilder internal constructor() : PolymorphicOptionsCol
      * ```
      */
     public fun discriminator(
-        propertyName: String = "type",
+        propertyName: String = TYPE,
         block: DiscriminatorBuilder.() -> Unit = {},
     ) {
         require(propertyName.isNotEmpty()) { "Discriminator propertyName cannot be empty" }

--- a/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchema.kt
+++ b/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchema.kt
@@ -2,6 +2,13 @@
 
 package kotlinx.schema.json
 
+import kotlinx.schema.json.JsonSchemaConstants.Keys.CONST
+import kotlinx.schema.json.JsonSchemaConstants.Keys.DEFS
+import kotlinx.schema.json.JsonSchemaConstants.Keys.REF
+import kotlinx.schema.json.JsonSchemaConstants.Types.ARRAY_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.BOOLEAN_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.OBJECT_TYPE
+import kotlinx.schema.json.JsonSchemaConstants.Types.STRING_TYPE
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
@@ -202,7 +209,7 @@ public data class JsonSchemaDefinition(
     public val items: PropertyDefinition? = null,
     public val oneOf: List<PropertyDefinition>? = null,
     public val discriminator: Discriminator? = null,
-    @SerialName($$"$defs") public val defs: Map<String, PropertyDefinition>? = null,
+    @SerialName(DEFS) public val defs: Map<String, PropertyDefinition>? = null,
 ) : PropertiesContainer
 
 /**
@@ -266,7 +273,7 @@ public sealed interface ValuePropertyDefinition : PropertyDefinition {
 @Serializable
 public data class StringPropertyDefinition(
     @Serializable(with = StringOrListSerializer::class) @EncodeDefault override val type: List<String> =
-        listOf("string"),
+        STRING_TYPE,
     override val description: String? = null,
     override val nullable: Boolean? = null,
     val format: String? = null,
@@ -304,7 +311,7 @@ public data class NumericPropertyDefinition(
 @Serializable
 public data class ArrayPropertyDefinition(
     @Serializable(with = StringOrListSerializer::class) @EncodeDefault override val type: List<String> =
-        listOf("array"),
+        ARRAY_TYPE,
     override val description: String? = null,
     override val nullable: Boolean? = null,
     @Serializable(with = ArrayEnumSerializer::class)
@@ -321,7 +328,7 @@ public data class ArrayPropertyDefinition(
 @Serializable
 public data class ObjectPropertyDefinition(
     @Serializable(with = StringOrListSerializer::class) @EncodeDefault override val type: List<String> =
-        listOf("object"),
+        OBJECT_TYPE,
     override val description: String? = null,
     override val nullable: Boolean? = null,
     @Serializable(with = ObjectEnumSerializer::class)
@@ -347,7 +354,7 @@ public data class ObjectPropertyDefinition(
 @Serializable
 public data class BooleanPropertyDefinition(
     @Serializable(with = StringOrListSerializer::class) @EncodeDefault override val type: List<String> =
-        listOf("boolean"),
+        BOOLEAN_TYPE,
     override val description: String? = null,
     override val nullable: Boolean? = null,
     @Serializable(with = BooleanEnumSerializer::class)
@@ -375,7 +382,7 @@ public data class GenericPropertyDefinition(
     @Serializable(with = PolymorphicEnumSerializer::class)
     val enum: List<JsonElement>? = null,
     val default: JsonElement? = null,
-    @SerialName("const") val constValue: JsonElement? = null,
+    @SerialName(CONST) val constValue: JsonElement? = null,
 ) : PropertyDefinition
 
 /**
@@ -383,7 +390,7 @@ public data class GenericPropertyDefinition(
  */
 @Serializable
 public data class ReferencePropertyDefinition(
-    @SerialName($$"$ref") val ref: String,
+    @SerialName(REF) val ref: String,
 ) : PropertyDefinition
 
 /**

--- a/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchemaConstants.kt
+++ b/kotlinx-schema-json/src/commonMain/kotlin/kotlinx/schema/json/JsonSchemaConstants.kt
@@ -1,10 +1,9 @@
-package kotlinx.schema.generator.json.internal
+package kotlinx.schema.json
 
 /**
  * Collection of special constants, such as keys and data types, from JSON schema definition.
  */
-@Suppress("MissingKDocForPublicAPI")
-public object JsonSchemaConsts {
+public object JsonSchemaConstants {
     /**
      * JSON Schema keys.
      */
@@ -49,5 +48,20 @@ public object JsonSchemaConsts {
         public const val ARRAY: String = "array"
         public const val OBJECT: String = "object"
         public const val NULL: String = "null"
+        public const val ANY: String = "any"
+
+        public val ARRAY_TYPE: List<String> = listOf(ARRAY)
+        public val ARRAY_OR_NULL_TYPE: List<String> = listOf(ARRAY, NULL)
+        public val BOOLEAN_TYPE: List<String> = listOf(BOOLEAN)
+        public val BOOLEAN_OR_NULL_TYPE: List<String> = listOf(BOOLEAN, NULL)
+        public val INTEGER_TYPE: List<String> = listOf(INTEGER)
+        public val INTEGER_OR_NULL_TYPE: List<String> = listOf(INTEGER, NULL)
+        public val NUMBER_TYPE: List<String> = listOf(NUMBER)
+        public val NUMBER_OR_NULL_TYPE: List<String> = listOf(NUMBER, NULL)
+        public val OBJECT_TYPE: List<String> = listOf(OBJECT)
+        public val OBJECT_OR_NULL_TYPE: List<String> = listOf(OBJECT, NULL)
+        public val STRING_TYPE: List<String> = listOf(STRING)
+        public val STRING_OR_NULL_TYPE: List<String> = listOf(STRING, NULL)
+        public val NULL_TYPE: List<String> = listOf(NULL)
     }
 }

--- a/kotlinx-schema-json/src/commonTest/kotlin/kotlinx/schema/json/StringEnumTest.kt
+++ b/kotlinx-schema-json/src/commonTest/kotlin/kotlinx/schema/json/StringEnumTest.kt
@@ -4,7 +4,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test


### PR DESCRIPTION
## Description

This change aims to reduce object allocation and ensure consistency.

- Renamed `JsonSchemaConsts` to `JsonSchemaConstants` across all modules, moved to kotlinx-schema-json
- Centralized JSON schema type definitions (`listOf("string")`, etc.) into reusable constants like `STRING_TYPE`, `BOOLEAN_TYPE`.
- Replaced hardcoded type and key strings with `JsonSchemaConstants` values for consistency and maintainability
- Optimized imports


### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [ ] **Tests added/updated** and passing locally
- [ ] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [ ] **No debug code**: Removed commented-out code and debug statements
