### PR TITLE
fix(ksp): Fix complex object parameters in function calling schemas

### DIFF
--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/reflect/ReflectionFunctionIntrospector.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/reflect/ReflectionFunctionIntrospector.kt
@@ -92,18 +92,6 @@ public object ReflectionFunctionIntrospector : SchemaIntrospector<KCallable<*>> 
             klass: KClass<*>,
             parentPrefix: String?,
         ): ObjectNode {
-            // Check for @Serializable annotation - not supported
-            val hasSerializable =
-                klass.annotations.any {
-                    it.annotationClass.qualifiedName == "kotlinx.serialization.Serializable"
-                }
-            require(!hasSerializable) {
-                "ReflectionFunctionIntrospector does not support classes annotated with @Serializable " +
-                    "(${klass.qualifiedName}). The kotlinx.serialization compiler plugin modifies the " +
-                    "constructor structure, making reflection-based introspection unreliable. " +
-                    "Please remove the @Serializable annotation or use a different introspector."
-            }
-
             val properties = mutableListOf<Property>()
             val requiredProperties = mutableSetOf<String>()
 

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToFunctionCallingSchemaTransformer.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/TypeGraphToFunctionCallingSchemaTransformer.kt
@@ -40,6 +40,22 @@ import kotlinx.schema.generator.json.FunctionCallingSchemaConfig.Companion.Defau
  * This transformer converts the IR representation of a function's parameters
  * into a tool schema suitable for LLM function calling APIs.
  *
+ * ## Flat Schema Structure (Default)
+ *
+ * Function schemas use a **FLAT/INLINED structure** by default (`useDefsAndRefs = false`):
+ * - Complex types are inlined at their point of use
+ * - No `$defs` section or `$ref` references
+ * - All type information embedded directly in parameters
+ *
+ * This design optimizes for:
+ * - LLM parsing simplicity (no reference resolution)
+ * - Self-contained schemas (single parameter object)
+ * - API compatibility (OpenAI, Anthropic, etc.)
+ *
+ * Contrast with [TypeGraphToJsonSchemaTransformer] which can use `$defs`/`$ref` for type reuse.
+ *
+ * ## Nullable Types
+ *
  * Nullable/optional fields are represented using union types that include "null"
  * (e.g., ["string", "null"]) instead of using the "nullable" flag.
  */

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspClassIntrospector.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspClassIntrospector.kt
@@ -1,20 +1,9 @@
 package kotlinx.schema.ksp.ir
 
-import com.google.devtools.ksp.getDeclaredProperties
-import com.google.devtools.ksp.isPublic
-import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Nullability
-import kotlinx.schema.generator.core.ir.Discriminator
-import kotlinx.schema.generator.core.ir.EnumNode
-import kotlinx.schema.generator.core.ir.ObjectNode
-import kotlinx.schema.generator.core.ir.PolymorphicNode
-import kotlinx.schema.generator.core.ir.PrimitiveKind
-import kotlinx.schema.generator.core.ir.PrimitiveNode
-import kotlinx.schema.generator.core.ir.Property
 import kotlinx.schema.generator.core.ir.SchemaIntrospector
-import kotlinx.schema.generator.core.ir.SubtypeRef
 import kotlinx.schema.generator.core.ir.TypeGraph
 import kotlinx.schema.generator.core.ir.TypeId
 import kotlinx.schema.generator.core.ir.TypeNode
@@ -29,189 +18,6 @@ internal class KspClassIntrospector : SchemaIntrospector<KSClassDeclaration> {
         val nodes = LinkedHashMap<TypeId, TypeNode>()
         val visiting = HashSet<KSClassDeclaration>()
 
-        fun TypeId.ensure(node: TypeNode) {
-            if (!nodes.containsKey(this)) nodes[this] = node
-        }
-
-        /**
-         * Handles generic type parameters or unknown declarations by falling back to kotlin.Any.
-         *
-         * This handler is invoked when the type declaration is not a KSClassDeclaration or lacks
-         * a qualified name (e.g., generic type parameters like `T` in `fun <T> foo(param: T)`).
-         *
-         * @param type The KSType to check
-         * @return TypeRef.Ref to kotlin.Any if fallback is needed, null otherwise
-         */
-        fun handleAnyFallback(type: KSType): TypeRef? {
-            val declAnyFallback = type.declaration !is KSClassDeclaration || type.declaration.qualifiedName == null
-            if (!declAnyFallback) return null
-
-            val anyId = TypeId("kotlin.Any")
-            anyId.ensure(
-                ObjectNode(
-                    name = "kotlin.Any",
-                    properties = emptyList(),
-                    required = emptySet(),
-                    description = null,
-                ),
-            )
-            return TypeRef.Ref(anyId, false)
-        }
-
-        /**
-         * Handles sealed class hierarchies by generating a PolymorphicNode.
-         *
-         * Creates a polymorphic schema with discriminator-based subtype resolution. Each sealed
-         * subclass is recursively processed and registered in the type graph. The discriminator
-         * maps simple class names to their fully qualified TypeIds.
-         *
-         * @param type The KSType to check
-         * @param nullable Whether the type reference should be nullable
-         * @param toRef Recursive mapper for processing subclass types
-         * @return TypeRef.Ref to the polymorphic node if this is a sealed class, null otherwise
-         */
-        fun handleSealedClass(
-            type: KSType,
-            nullable: Boolean,
-            toRef: (KSType) -> TypeRef,
-        ): TypeRef? {
-            val decl = type.sealedClassDeclOrNull() ?: return null
-            val id = decl.typeId()
-
-            processWithCycleDetection(decl, id, nodes, visiting) {
-                // Find all sealed subclasses
-                val sealedSubclasses = decl.getSealedSubclasses().toList()
-
-                // Create SubtypeRef for each sealed subclass using their typeId()
-                val subtypes = sealedSubclasses.map { SubtypeRef(it.typeId()) }
-
-                // Build discriminator mapping: discriminator value (simple name) -> TypeId (full qualified name)
-                val discriminatorMapping =
-                    sealedSubclasses.associate { it.simpleName.asString() to it.typeId() }
-
-                // Process each sealed subclass
-                sealedSubclasses.forEach { toRef(it.asType(emptyList())) }
-
-                PolymorphicNode(
-                    baseName = decl.simpleName.asString(),
-                    subtypes = subtypes,
-                    discriminator = Discriminator(name = "type", required = true, mapping = discriminatorMapping),
-                    description = extractDescription(decl) { decl.descriptionFromKdoc() },
-                )
-            }
-
-            return TypeRef.Ref(id, nullable)
-        }
-
-        /**
-         * Handles enum classes by generating an EnumNode.
-         *
-         * Extracts all enum entries and creates a schema node that constrains values to the
-         * declared enum constants. Enum entries are identified by ClassKind.ENUM_ENTRY.
-         *
-         * @param type The KSType to check
-         * @param nullable Whether the type reference should be nullable
-         * @return TypeRef.Ref to the enum node if this is an enum class, null otherwise
-         */
-        fun handleEnum(
-            type: KSType,
-            nullable: Boolean,
-        ): TypeRef? {
-            val decl = type.enumClassDeclOrNull() ?: return null
-            val id = decl.typeId()
-
-            processWithCycleDetection(decl, id, nodes, visiting) {
-                val entries =
-                    decl.declarations
-                        .filterIsInstance<KSClassDeclaration>()
-                        .filter { it.classKind == ClassKind.ENUM_ENTRY }
-                        .map { it.simpleName.asString() }
-                        .toList()
-
-                EnumNode(
-                    name = decl.qualifiedName?.asString() ?: decl.simpleName.asString(),
-                    entries = entries,
-                    description = extractDescription(decl) { decl.descriptionFromKdoc() },
-                )
-            }
-
-            return TypeRef.Ref(id, nullable)
-        }
-
-        /**
-         * Handles regular objects and data classes by generating an ObjectNode.
-         *
-         * Prefers primary constructor parameters for data classes (extracting parameter names,
-         * types, and default value presence). Falls back to public properties for objects and
-         * classes without primary constructors. Properties without defaults are marked as required.
-         *
-         * Note: KSP does not provide access to default value expressions at compile-time
-         * (https://github.com/google/ksp/issues/1868), so only the presence of defaults is tracked.
-         *
-         * @param type The KSType to check
-         * @param nullable Whether the type reference should be nullable
-         * @param toRef Recursive mapper for processing property types
-         * @return TypeRef.Ref to the object node if this is a class/object, null otherwise
-         */
-        fun handleObjectOrClass(
-            type: KSType,
-            nullable: Boolean,
-            toRef: (KSType) -> TypeRef,
-        ): TypeRef? {
-            val decl = type.declaration as? KSClassDeclaration ?: return null
-            val id = decl.typeId()
-
-            processWithCycleDetection(decl, id, nodes, visiting) {
-                val props = ArrayList<Property>()
-                val required = LinkedHashSet<String>()
-
-                /**
-                 * Helper to add a property and track whether it's required.
-                 *
-                 * Properties without default values are automatically added to the required set.
-                 */
-                fun addProperty(
-                    name: String,
-                    type: KSType,
-                    description: String?,
-                    hasDefaultValue: Boolean,
-                ) {
-                    if (!hasDefaultValue) required += name
-                    props += createProperty(name, toRef(type), description, hasDefaultValue)
-                }
-
-                // Prefer primary constructor parameters for data classes; fall back to public properties
-                val params = decl.primaryConstructor?.parameters.orEmpty()
-                if (params.isNotEmpty()) {
-                    // Note: KSP does not provide access to default value expressions at compile-time.
-                    // https://github.com/google/ksp/issues/1868
-                    // Only runtime reflection can extract actual default values.
-                    params.forEach { p ->
-                        val name = p.name?.asString() ?: return@forEach
-                        addProperty(name, p.type.resolve(), extractDescription(p) { null }, p.hasDefault)
-                    }
-                } else {
-                    decl.getDeclaredProperties().filter { it.isPublic() }.forEach { prop ->
-                        addProperty(
-                            prop.simpleName.asString(),
-                            prop.type.resolve(),
-                            extractDescription(prop) { prop.descriptionFromKdoc() },
-                            false,
-                        )
-                    }
-                }
-
-                ObjectNode(
-                    name = decl.qualifiedName?.asString() ?: decl.simpleName.asString(),
-                    properties = props,
-                    required = required,
-                    description = extractDescription(decl) { decl.descriptionFromKdoc() },
-                )
-            }
-
-            return TypeRef.Ref(id, nullable)
-        }
-
         /**
          * Converts a KSType to a TypeRef by attempting each handler in priority order.
          *
@@ -221,21 +27,27 @@ internal class KspClassIntrospector : SchemaIntrospector<KSClassDeclaration> {
          * 3. Sealed class hierarchies -> PolymorphicNode via [handleSealedClass]
          * 4. Enum classes -> EnumNode via [handleEnum]
          * 5. Regular objects/classes -> ObjectNode via [handleObjectOrClass]
-         * 6. Final fallback -> String primitive
+         *
+         * All types should be handled by one of the above handlers. If not, an exception is thrown
+         * to fail fast and help identify missing handler cases during development.
          *
          * @param type The KSType to convert
          * @return TypeRef representing the type in the schema IR
+         * @throws IllegalArgumentException if the type cannot be handled by any handler
          */
         fun toRef(type: KSType): TypeRef {
             val nullable = type.nullability == Nullability.NULLABLE
 
             // Try each handler in order, using elvis operator chain for single return
-            return resolveBasicTypeOrNull(type, ::toRef)
-                ?: handleAnyFallback(type)
-                ?: handleSealedClass(type, nullable, ::toRef)
-                ?: handleEnum(type, nullable)
-                ?: handleObjectOrClass(type, nullable, ::toRef)
-                ?: TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING), nullable)
+            return requireNotNull(
+                resolveBasicTypeOrNull(type, ::toRef)
+                    ?: handleAnyFallback(type, nodes)
+                    ?: handleSealedClass(type, nullable, nodes, visiting, ::toRef)
+                    ?: handleEnum(type, nullable, nodes, visiting)
+                    ?: handleObjectOrClass(type, nullable, nodes, visiting, ::toRef),
+            ) {
+                "Unexpected type that couldn't be handled: ${type.declaration.qualifiedName}"
+            }
         }
 
         val rootRef = TypeRef.Ref(root.typeId())

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspFunctionIntrospector.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspFunctionIntrospector.kt
@@ -4,8 +4,6 @@ import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Nullability
 import kotlinx.schema.generator.core.ir.ObjectNode
-import kotlinx.schema.generator.core.ir.PrimitiveKind
-import kotlinx.schema.generator.core.ir.PrimitiveNode
 import kotlinx.schema.generator.core.ir.Property
 import kotlinx.schema.generator.core.ir.SchemaIntrospector
 import kotlinx.schema.generator.core.ir.TypeGraph
@@ -24,6 +22,7 @@ import kotlinx.schema.generator.core.ir.TypeRef
  * - Suspend functions (treated as regular functions)
  * - Extension functions (receiver type handled separately)
  * - Generic functions (using star projection)
+ * - Complex parameter types (data classes, enums, sealed classes)
  *
  * Does NOT support:
  * - Lambda parameters with complex signatures
@@ -31,17 +30,38 @@ import kotlinx.schema.generator.core.ir.TypeRef
 internal class KspFunctionIntrospector : SchemaIntrospector<KSFunctionDeclaration> {
     override fun introspect(root: KSFunctionDeclaration): TypeGraph {
         val nodes = LinkedHashMap<TypeId, TypeNode>()
+        val visiting = HashSet<com.google.devtools.ksp.symbol.KSClassDeclaration>()
 
+        /**
+         * Converts a KSType to a TypeRef using the same resolution strategy as KspClassIntrospector.
+         *
+         * Resolution strategy:
+         * 1. Basic types (primitives and collections) via [resolveBasicTypeOrNull]
+         * 2. Generic type parameters and unknowns -> kotlin.Any via [handleAnyFallback]
+         * 3. Sealed class hierarchies -> PolymorphicNode via [handleSealedClass]
+         * 4. Enum classes -> EnumNode via [handleEnum]
+         * 5. Regular objects/classes -> ObjectNode via [handleObjectOrClass]
+         *
+         * All types should be handled by one of the above handlers. If not, an exception is thrown
+         * to fail fast and help identify missing handler cases during development.
+         *
+         * @param type The KSType to convert
+         * @return TypeRef representing the type in the schema IR
+         * @throws IllegalArgumentException if the type cannot be handled by any handler
+         */
         fun toRef(type: KSType): TypeRef {
-            // Try basic types (primitives and collections)
-            resolveBasicTypeOrNull(type, ::toRef)?.let { return it }
+            val nullable = type.nullability == Nullability.NULLABLE
 
-            // For complex types (data classes, enums, etc.), use simplified approach
-            // Function schemas inline complex types as strings for simplicity
-            return TypeRef.Inline(
-                PrimitiveNode(PrimitiveKind.STRING),
-                type.nullability == Nullability.NULLABLE,
-            )
+            // Try each handler in order, using elvis operator chain for single return
+            return requireNotNull(
+                resolveBasicTypeOrNull(type, ::toRef)
+                    ?: handleAnyFallback(type, nodes)
+                    ?: handleSealedClass(type, nullable, nodes, visiting, ::toRef)
+                    ?: handleEnum(type, nullable, nodes, visiting)
+                    ?: handleObjectOrClass(type, nullable, nodes, visiting, ::toRef),
+            ) {
+                "Unexpected type that couldn't be handled: ${type.declaration.qualifiedName}"
+            }
         }
 
         // Extract function information

--- a/ksp-integration-tests/src/main/kotlin/kotlinx/schema/integration/functions/InstanceFunctions.kt
+++ b/ksp-integration-tests/src/main/kotlin/kotlinx/schema/integration/functions/InstanceFunctions.kt
@@ -5,6 +5,7 @@ package kotlinx.schema.integration.functions
 import kotlinx.coroutines.delay
 import kotlinx.schema.Description
 import kotlinx.schema.Schema
+import kotlinx.schema.integration.type.Product
 
 /**
  * Service class with instance functions (both normal and suspend) for testing.
@@ -136,14 +137,8 @@ class ProductRepository {
     @Schema
     @Description("Saves a product to the database asynchronously")
     suspend fun saveProduct(
-        @Description("Product ID (null for new products)")
-        id: Long?,
-        @Description("Product name")
-        name: String,
-        @Description("Product price")
-        price: Double,
-        @Description("Stock quantity")
-        stock: Int = 0,
+        @Description("Product to save")
+        product: Product,
     ): Long {
         delay(1)
         @Suppress("MagicNumber")

--- a/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/functions/InstanceFunctionsTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/functions/InstanceFunctionsTest.kt
@@ -88,7 +88,7 @@ class InstanceFunctionsTest {
     }
 
     @Test
-    fun `ProductRepository saveProduct suspend function generates correct schema`() {
+    fun `function with complex type parameter`() {
         val schema = ProductRepository::class.saveProductJsonSchemaString()
 
         // language=json
@@ -102,24 +102,43 @@ class InstanceFunctionsTest {
               "parameters": {
                 "type": "object",
                 "properties": {
-                  "id": {
-                    "type": ["integer", "null"],
-                    "description": "Product ID (null for new products)"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Product name"
-                  },
-                  "price": {
-                    "type": "number",
-                    "description": "Product price"
-                  },
-                  "stock": {
-                    "type": "integer",
-                    "description": "Stock quantity"
+                  "product": {
+                    "type": "object",
+                    "description": "Product to save",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "description": "Unique identifier for the product"
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Human-readable product name"
+                      },
+                      "description": {
+                        "type": ["string", "null"],
+                        "description": "Optional detailed description of the product"
+                      },
+                      "price": {
+                        "type": "number",
+                        "description": "Unit price expressed as a decimal number"
+                      },
+                      "inStock": {
+                        "type": "boolean",
+                        "description": "Whether the product is currently in stock"
+                      },
+                      "tags": {
+                        "type": "array",
+                        "description": "List of tags for categorization and search",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": ["id", "name", "description", "price", "inStock", "tags"],
+                    "additionalProperties": false
                   }
                 },
-                "required": ["id", "name", "price", "stock"],
+                "required": ["product"],
                 "additionalProperties": false
               }
             }


### PR DESCRIPTION
fix(ksp): Fix complex object parameters in function calling schemas

Fixed handling complex objects as funciton parameters.

Changes:

- Moved type handlers (`handleAnyFallback`, `handleSealedClass`, `handleEnum`, `handleObjectOrClass`) to shared utility functions for reuse and maintainability.
- Enhanced error messages for unhandled KSType cases in `toRef` methods.
- Updated schema generation tests to handle complex parameter types and verify flat schema structure.

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [ ] **No debug code**: Removed commented-out code and debug statements

