### PR TITLE
refactor(core): Refactor introspectors, extract shared state management

### DIFF
--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/ir/BaseIntrospectionContext.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/core/ir/BaseIntrospectionContext.kt
@@ -1,0 +1,77 @@
+package kotlinx.schema.generator.core.ir
+
+/**
+ * Base context for introspection that maintains state and provides common utilities.
+ *
+ * This abstraction extracts common patterns from Reflection, KSP, and potential
+ * Serialization introspectors, including:
+ * - State management (discovered nodes, visiting set, type cache)
+ * - Cycle detection lifecycle
+ * - Type resolution patterns
+ *
+ * Type parameters:
+ * - TDecl: Declaration type (KClass, KSClassDeclaration, SerialDescriptor)
+ * - TType: Type usage type (KType, KSType, SerialDescriptor)
+ *
+ * Note: For kotlinx.serialization, SerialDescriptor serves as both declaration and type,
+ * so both type parameters would be SerialDescriptor.
+ *
+ * @suppress Not part of public API - used internally by introspector implementations.
+ */
+public abstract class BaseIntrospectionContext<TDecl : Any, TType : Any> {
+    /**
+     * Map of discovered type nodes indexed by their type ID.
+     * LinkedHashMap preserves discovery order for deterministic output.
+     */
+    protected val discoveredNodes: MutableMap<TypeId, TypeNode> = linkedMapOf()
+
+    /**
+     * Set of declarations currently being visited (for cycle detection).
+     * When a type references itself (directly or indirectly), we detect the cycle
+     * and avoid infinite recursion by checking this set.
+     *
+     * Protected to allow subclasses (like KSP) to expose it to handler functions.
+     */
+    protected val visitingDeclarations: MutableSet<TDecl> = mutableSetOf()
+
+    /**
+     * Cache of type references to avoid redundant processing.
+     * Stores non-nullable refs to declarations for reuse.
+     */
+    protected val typeRefCache: MutableMap<TDecl, TypeRef> = mutableMapOf()
+
+    /**
+     * Cycle detection helper that manages visiting set lifecycle.
+     *
+     * Pattern used by all introspectors:
+     * 1. Check if already discovered or currently being visited
+     * 2. Mark as visiting
+     * 3. Build the node (which may recursively call toRef)
+     * 4. Add to discovered nodes
+     * 5. Unmark as visiting
+     *
+     * @param decl The declaration being processed
+     * @param id The TypeId for this declaration
+     * @param nodeBuilder Lambda that constructs the TypeNode
+     * @return true if node was created, false if already visited/in progress
+     */
+    protected inline fun withCycleDetection(
+        decl: TDecl,
+        id: TypeId,
+        nodeBuilder: () -> TypeNode,
+    ): Boolean {
+        if (id in discoveredNodes || decl in visitingDeclarations) {
+            return false
+        }
+
+        visitingDeclarations += decl
+        try {
+            val node = nodeBuilder()
+            discoveredNodes[id] = node
+            return true
+        } finally {
+            visitingDeclarations -= decl
+        }
+    }
+
+}

--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/reflect/ReflectionFunctionIntrospector.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/reflect/ReflectionFunctionIntrospector.kt
@@ -30,7 +30,7 @@ public object ReflectionFunctionIntrospector : SchemaIntrospector<KCallable<*>> 
 
         val context = IntrospectionContext()
         val rootRef = context.convertFunctionToTypeRef(root)
-        return TypeGraph(root = rootRef, nodes = context.discoveredNodes)
+        return TypeGraph(root = rootRef, nodes = context.nodes())
     }
 
     /**
@@ -38,7 +38,8 @@ public object ReflectionFunctionIntrospector : SchemaIntrospector<KCallable<*>> 
      * visited classes, and type reference cache.
      */
     @Suppress("TooManyFunctions")
-    private class IntrospectionContext : BaseIntrospectionContext() {
+    private class IntrospectionContext : ReflectionIntrospectionContext() {
+        fun nodes() = discoveredNodes
         /**
          * Converts a KCallable (function) to a TypeRef representing its parameters as an object.
          */

--- a/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/reflect/reflectionUtils.kt
+++ b/kotlinx-schema-generator-core/src/main/kotlin/kotlinx/schema/generator/reflect/reflectionUtils.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KProperty1
 /*
  * Utility functions for reflection-based introspection.
  *
- * These functions are shared between [ReflectionIntrospector] and [ReflectionFunctionIntrospector]
+ * These functions are shared between [ReflectionClassIntrospector] and [ReflectionFunctionIntrospector]
  * to avoid code duplication.
  */
 

--- a/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectorTest.kt
+++ b/kotlinx-schema-generator-core/src/test/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectorTest.kt
@@ -48,7 +48,7 @@ class ReflectionIntrospectorTest {
         ) : Shape()
     }
 
-    private val introspector = ReflectionIntrospector
+    private val introspector = ReflectionClassIntrospector
 
     @Test
     @Suppress("LongMethod")

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/ReflectionClassJsonSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/ReflectionClassJsonSchemaGenerator.kt
@@ -1,7 +1,7 @@
 package kotlinx.schema.generator.json
 
 import kotlinx.schema.generator.core.AbstractSchemaGenerator
-import kotlinx.schema.generator.reflect.ReflectionIntrospector
+import kotlinx.schema.generator.reflect.ReflectionClassIntrospector
 import kotlinx.schema.json.JsonSchema
 import kotlinx.serialization.json.Json
 import kotlin.reflect.KClass
@@ -21,7 +21,7 @@ public class ReflectionClassJsonSchemaGenerator(
     private val json: Json,
     config: JsonSchemaConfig,
 ) : AbstractSchemaGenerator<KClass<out Any>, JsonSchema>(
-        introspector = ReflectionIntrospector,
+        introspector = ReflectionClassIntrospector,
         typeGraphTransformer =
             TypeGraphToJsonSchemaTransformer(
                 config = config,
@@ -33,8 +33,7 @@ public class ReflectionClassJsonSchemaGenerator(
         config = JsonSchemaConfig.Default,
     )
 
-    override fun getRootName(target: KClass<out Any>): String =
-        target.qualifiedName ?: target.simpleName ?: "Anonymous"
+    override fun getRootName(target: KClass<out Any>): String = target.qualifiedName ?: target.simpleName ?: "Anonymous"
 
     override fun targetType(): KClass<KClass<out Any>> = KClass::class
 

--- a/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/JsonSchemaConfigTest.kt
+++ b/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/JsonSchemaConfigTest.kt
@@ -20,7 +20,7 @@ class JsonSchemaConfigTest {
             )
         val transformer = TypeGraphToJsonSchemaTransformer(config)
         val typeGraph =
-            kotlinx.schema.generator.reflect.ReflectionIntrospector
+            kotlinx.schema.generator.reflect.ReflectionClassIntrospector
                 .introspect(PersonWithOptionals::class)
         val schema = transformer.transform(typeGraph, "PersonWithOptionals")
 
@@ -42,7 +42,7 @@ class JsonSchemaConfigTest {
             )
         val transformer = TypeGraphToJsonSchemaTransformer(config)
         val typeGraph =
-            kotlinx.schema.generator.reflect.ReflectionIntrospector
+            kotlinx.schema.generator.reflect.ReflectionClassIntrospector
                 .introspect(PersonWithOptionals::class)
         val schema = transformer.transform(typeGraph, "PersonWithOptionals")
 
@@ -64,7 +64,7 @@ class JsonSchemaConfigTest {
             )
         val transformer = TypeGraphToJsonSchemaTransformer(config)
         val typeGraph =
-            kotlinx.schema.generator.reflect.ReflectionIntrospector
+            kotlinx.schema.generator.reflect.ReflectionClassIntrospector
                 .introspect(PersonWithOptionals::class)
         val schema = transformer.transform(typeGraph, "PersonWithOptionals")
 

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspClassIntrospector.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspClassIntrospector.kt
@@ -1,58 +1,19 @@
 package kotlinx.schema.ksp.ir
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSType
-import com.google.devtools.ksp.symbol.Nullability
 import kotlinx.schema.generator.core.ir.SchemaIntrospector
 import kotlinx.schema.generator.core.ir.TypeGraph
-import kotlinx.schema.generator.core.ir.TypeId
-import kotlinx.schema.generator.core.ir.TypeNode
 import kotlinx.schema.generator.core.ir.TypeRef
 
 /**
  * KSP-backed Schema IR introspector. Focuses on classes and enums; generics use star-projection.
  */
 internal class KspClassIntrospector : SchemaIntrospector<KSClassDeclaration> {
-    @Suppress("CyclomaticComplexMethod")
     override fun introspect(root: KSClassDeclaration): TypeGraph {
-        val nodes = LinkedHashMap<TypeId, TypeNode>()
-        val visiting = HashSet<KSClassDeclaration>()
-
-        /**
-         * Converts a KSType to a TypeRef by attempting each handler in priority order.
-         *
-         * Resolution strategy:
-         * 1. Basic types (primitives and collections) via [resolveBasicTypeOrNull]
-         * 2. Generic type parameters and unknowns -> kotlin.Any via [handleAnyFallback]
-         * 3. Sealed class hierarchies -> PolymorphicNode via [handleSealedClass]
-         * 4. Enum classes -> EnumNode via [handleEnum]
-         * 5. Regular objects/classes -> ObjectNode via [handleObjectOrClass]
-         *
-         * All types should be handled by one of the above handlers. If not, an exception is thrown
-         * to fail fast and help identify missing handler cases during development.
-         *
-         * @param type The KSType to convert
-         * @return TypeRef representing the type in the schema IR
-         * @throws IllegalArgumentException if the type cannot be handled by any handler
-         */
-        fun toRef(type: KSType): TypeRef {
-            val nullable = type.nullability == Nullability.NULLABLE
-
-            // Try each handler in order, using elvis operator chain for single return
-            return requireNotNull(
-                resolveBasicTypeOrNull(type, ::toRef)
-                    ?: handleAnyFallback(type, nodes)
-                    ?: handleSealedClass(type, nullable, nodes, visiting, ::toRef)
-                    ?: handleEnum(type, nullable, nodes, visiting)
-                    ?: handleObjectOrClass(type, nullable, nodes, visiting, ::toRef),
-            ) {
-                "Unexpected type that couldn't be handled: ${type.declaration.qualifiedName}"
-            }
-        }
-
+        val context = KspIntrospectionContext()
         val rootRef = TypeRef.Ref(root.typeId())
         // ensure root node is populated
-        toRef(root.asType(emptyList()))
-        return TypeGraph(root = rootRef, nodes = nodes)
+        context.toRef(root.asType(emptyList()))
+        return TypeGraph(root = rootRef, nodes = context.nodes)
     }
 }

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspFunctionIntrospector.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspFunctionIntrospector.kt
@@ -1,14 +1,11 @@
 package kotlinx.schema.ksp.ir
 
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSType
-import com.google.devtools.ksp.symbol.Nullability
 import kotlinx.schema.generator.core.ir.ObjectNode
 import kotlinx.schema.generator.core.ir.Property
 import kotlinx.schema.generator.core.ir.SchemaIntrospector
 import kotlinx.schema.generator.core.ir.TypeGraph
 import kotlinx.schema.generator.core.ir.TypeId
-import kotlinx.schema.generator.core.ir.TypeNode
 import kotlinx.schema.generator.core.ir.TypeRef
 
 /**
@@ -29,40 +26,7 @@ import kotlinx.schema.generator.core.ir.TypeRef
  */
 internal class KspFunctionIntrospector : SchemaIntrospector<KSFunctionDeclaration> {
     override fun introspect(root: KSFunctionDeclaration): TypeGraph {
-        val nodes = LinkedHashMap<TypeId, TypeNode>()
-        val visiting = HashSet<com.google.devtools.ksp.symbol.KSClassDeclaration>()
-
-        /**
-         * Converts a KSType to a TypeRef using the same resolution strategy as KspClassIntrospector.
-         *
-         * Resolution strategy:
-         * 1. Basic types (primitives and collections) via [resolveBasicTypeOrNull]
-         * 2. Generic type parameters and unknowns -> kotlin.Any via [handleAnyFallback]
-         * 3. Sealed class hierarchies -> PolymorphicNode via [handleSealedClass]
-         * 4. Enum classes -> EnumNode via [handleEnum]
-         * 5. Regular objects/classes -> ObjectNode via [handleObjectOrClass]
-         *
-         * All types should be handled by one of the above handlers. If not, an exception is thrown
-         * to fail fast and help identify missing handler cases during development.
-         *
-         * @param type The KSType to convert
-         * @return TypeRef representing the type in the schema IR
-         * @throws IllegalArgumentException if the type cannot be handled by any handler
-         */
-        fun toRef(type: KSType): TypeRef {
-            val nullable = type.nullability == Nullability.NULLABLE
-
-            // Try each handler in order, using elvis operator chain for single return
-            return requireNotNull(
-                resolveBasicTypeOrNull(type, ::toRef)
-                    ?: handleAnyFallback(type, nodes)
-                    ?: handleSealedClass(type, nullable, nodes, visiting, ::toRef)
-                    ?: handleEnum(type, nullable, nodes, visiting)
-                    ?: handleObjectOrClass(type, nullable, nodes, visiting, ::toRef),
-            ) {
-                "Unexpected type that couldn't be handled: ${type.declaration.qualifiedName}"
-            }
-        }
+        val context = KspIntrospectionContext()
 
         // Extract function information
         val functionName = root.simpleName.asString()
@@ -76,7 +40,7 @@ internal class KspFunctionIntrospector : SchemaIntrospector<KSFunctionDeclaratio
             val paramName = param.name?.asString() ?: return@forEach
             val paramType = param.type.resolve()
 
-            val typeRef = toRef(paramType)
+            val typeRef = context.toRef(paramType)
 
             // Extract description from annotations or KDoc
             val description = extractDescription(param) { null }
@@ -106,7 +70,7 @@ internal class KspFunctionIntrospector : SchemaIntrospector<KSFunctionDeclaratio
                 description = functionDescription,
             )
 
-        nodes[id] = objectNode
-        return TypeGraph(root = TypeRef.Ref(id, nullable = false), nodes = nodes)
+        context.nodes[id] = objectNode
+        return TypeGraph(root = TypeRef.Ref(id, nullable = false), nodes = context.nodes)
     }
 }

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspIntrospectionContext.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspIntrospectionContext.kt
@@ -1,0 +1,70 @@
+package kotlinx.schema.ksp.ir
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.Nullability
+import kotlinx.schema.generator.core.ir.BaseIntrospectionContext
+import kotlinx.schema.generator.core.ir.TypeId
+import kotlinx.schema.generator.core.ir.TypeNode
+import kotlinx.schema.generator.core.ir.TypeRef
+
+/**
+ * Shared introspection context for KSP-based introspectors.
+ *
+ * Eliminates toRef() duplication between KspClassIntrospector and KspFunctionIntrospector
+ * by providing a single, well-tested implementation of the type resolution strategy.
+ *
+ * Extends [BaseIntrospectionContext] to inherit state management and cycle detection,
+ * while implementing KSP-specific type resolution logic.
+ *
+ * Resolution strategy (applied in order):
+ * 1. Basic types (primitives and collections) via [resolveBasicTypeOrNull]
+ * 2. Generic type parameters and unknowns -> kotlin.Any via [handleAnyFallback]
+ * 3. Sealed class hierarchies -> PolymorphicNode via [handleSealedClass]
+ * 4. Enum classes -> EnumNode via [handleEnum]
+ * 5. Regular objects/classes -> ObjectNode via [handleObjectOrClass]
+ */
+internal class KspIntrospectionContext : BaseIntrospectionContext<KSClassDeclaration, KSType>() {
+    /**
+     * Exposes discovered nodes as a mutable map for handler functions.
+     * KSP handlers are top-level functions that need direct mutable access.
+     */
+    internal val nodes: MutableMap<TypeId, TypeNode>
+        get() = discoveredNodes
+
+    /**
+     * Exposes visiting declarations as a mutable set for handler functions.
+     * KSP handlers are top-level functions that need direct mutable access.
+     */
+    internal val visiting: MutableSet<KSClassDeclaration>
+        get() = visitingDeclarations
+
+    /**
+     * Converts a KSType to a TypeRef using the standard resolution strategy.
+     *
+     * This method implements the common type resolution pattern used across all KSP
+     * introspectors. It tries each handler in priority order, using elvis operator
+     * chain to return the first successful match.
+     *
+     * All types should be handled by one of the resolution steps. If not, an exception
+     * is thrown to fail fast and help identify missing handler cases during development.
+     *
+     * @param type The KSType to convert
+     * @return TypeRef representing the type in the schema IR
+     * @throws IllegalArgumentException if the type cannot be handled by any handler
+     */
+    fun toRef(type: KSType): TypeRef {
+        val nullable = type.nullability == Nullability.NULLABLE
+
+        // Try each handler in order, using elvis operator chain for single return
+        return requireNotNull(
+            resolveBasicTypeOrNull(type, ::toRef)
+                ?: handleAnyFallback(type, nodes)
+                ?: handleSealedClass(type, nullable, nodes, visiting, ::toRef)
+                ?: handleEnum(type, nullable, nodes, visiting)
+                ?: handleObjectOrClass(type, nullable, nodes, visiting, ::toRef),
+        ) {
+            "Unexpected type that couldn't be handled: ${type.declaration.qualifiedName}"
+        }
+    }
+}


### PR DESCRIPTION
# refactor(core): Refactor introspectors, extract shared state management

Eliminate duplicated code by introducing a generic base class for introspection state management and cycle detection.

## Changes:

- Add BaseIntrospectionContext<TDecl, TType> with shared state (discovered nodes, visiting set, type cache) and withCycleDetection() helper
- Make KspIntrospectionContext extend base, removing duplicate state
- Rename BaseReflectionIntrospectionContext → ReflectionIntrospectionContext for consistency (extends base)
- Remove unused isVisiting() and isDiscovered() helper methods
- Simplify node access pattern (remove redundant getDiscoveredNodes())

## Architecture:

- Generic type parameters enable reuse across Reflection (KClass/KType), KSP (KSClassDeclaration/KSType), and future Serialization backends
- KSP handlers remain top-level functions with mutable state access via exposed properties (pragmatic choice over complex handler refactoring)
- BaseIntrospectionContext is public (@suppress) to enable cross-module inheritance (core → ksp)

Required for #84 

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [ ] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements
