### PR TITLE
refactor(json)!: Replace `KSerializer` with `SerialDescriptor` for JSON Schema generation (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Quick Links:
 **Dual Generation Modes:**
 - **Compile-time (KSP)**: Zero runtime overhead, multiplatform, for your annotated classes
 - **Runtime (Reflection)**: JVM-only, for any class including third-party libraries
+- **Runtime (SerialDescriptor)**: Kotlin serializable classes
 
 **LLM Integration:**
 - First-class support for OpenAI/Anthropic function calling format

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ keeping behavior consistent across JVM, JS, Native, and Wasm.
 
 **Architecture goals:**
 
-- **Unified IR**: Separate schema sources (KSP, reflection, or [KSerializer][kser]) from output targets
+- **Unified IR**: Separate schema sources (KSP, reflection, or [SerialDescriptor][kser-descriptor]) from output targets
 - **Multiplatform (KSP)**: Support schema generation across all Kotlin targets.
 - **Extensibility**: Enable third-party annotations, custom introspectors and transformations.
 - **Zero runtime overhead on KSP**: Compile-time generation for performance-sensitive paths.
@@ -23,7 +23,7 @@ The library implements the following pipeline:
 graph LR
     subgraph Sources["📦 SOURCES"]
         Kotlin["Kotlin Classes<br/>@Schema annotated"]
-        KSerializer["KSerializer"]
+        KSerializer["SerialDescriptor"]
         Java["Java Classes<br/>Third-party libs"]
         Functions["Kotlin Functions"]
     end
@@ -87,7 +87,7 @@ graph LR
 
 **The Transformation Story:**
 
-1. **Sources** — Kotlin classes, Java classes, Kotlin functions, or [KSerializer][kser] serve as input
+1. **Sources** — Kotlin classes, Java classes, Kotlin functions, or [SerialDescriptor][kser-descriptor] serve as input
 2. **Introspectors** — Extract type information at compile-time (KSP) or runtime (Reflection, Serialization)
 3. **TypeGraph** — Unified internal representation containing all type metadata
 4. **Transformers** — Convert TypeGraph to JSON Schema or Function Calling format
@@ -131,7 +131,7 @@ Top-level modules you might interact with:
 - **kotlinx-schema-json** — type-safe models and DSL for building JSON Schema definitions programmatically
 - **kotlinx-schema-generator-core** — internal representation (IR) for schema descriptions, introspection utils,
   generator interfaces
-- **kotlinx-schema-generator-json** — JSON Schema transformer from the IR
+- **kotlinx-schema-generator-json** — JSON Schema transformer from the IR, kotlinx-serialization schema generator
 - **kotlinx-schema-ksp** — KSP processor that scans your code and generates the extension properties:
     - `KClass<T>.jsonSchema: JsonObject`
     - `KClass<T>.jsonSchemaString: String`
@@ -175,5 +175,5 @@ sequenceDiagram
 4. _TypeGraphTransformer_ converts a _TypeGraph_ to a target representation (e.g., JSON Schema)
    with respect to respecting _Config_ object and returns it to SchemaGenerator
 
-[kser]: https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-k-serializer/
+[kser-descriptor]: https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization.descriptors/-serial-descriptor/
 

--- a/kotlinx-schema-generator-json/api/kotlinx-schema-generator-json.api
+++ b/kotlinx-schema-generator-json/api/kotlinx-schema-generator-json.api
@@ -125,6 +125,6 @@ public final class kotlinx/schema/generator/json/serialization/SerializationClas
 	public fun <init> (Lkotlinx/serialization/json/Json;)V
 	public synthetic fun <init> (Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun introspect (Ljava/lang/Object;)Lkotlinx/schema/generator/core/ir/TypeGraph;
-	public fun introspect (Lkotlinx/serialization/KSerializer;)Lkotlinx/schema/generator/core/ir/TypeGraph;
+	public fun introspect (Lkotlinx/serialization/descriptors/SerialDescriptor;)Lkotlinx/schema/generator/core/ir/TypeGraph;
 }
 

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGenerator.kt
@@ -4,25 +4,25 @@ import kotlinx.schema.generator.core.AbstractSchemaGenerator
 import kotlinx.schema.generator.json.JsonSchemaConfig
 import kotlinx.schema.generator.json.TypeGraphToJsonSchemaTransformer
 import kotlinx.schema.json.JsonSchema
-import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.json.Json
 import kotlin.reflect.KClass
 
 /**
- * A generator for producing JSON Schema representations of Kotlin classes using reflection.
+ * A generator for producing JSON Schema representations from kotlinx.serialization descriptors.
  *
- * This class utilizes reflection-based introspection to analyze Kotlin `KClass` definitions
+ * This class utilizes kotlinx.serialization introspection to analyze [SerialDescriptor] instances
  * and generate JSON Schema objects. It is built on top of the `AbstractSchemaGenerator` and works
  * with a configurable `JsonSchemaConfig` to define schema generation behavior.
  *
- * @constructor Creates an instance of `ReflectionClassJsonSchemaGenerator`.
+ * @constructor Creates an instance of `SerializationClassJsonSchemaGenerator`.
  * @param config Configuration for generating JSON Schemas, such as formatting details
  * and handling of optional nullable properties. Defaults to [JsonSchemaConfig.Default].
  */
 public class SerializationClassJsonSchemaGenerator(
     private val json: Json,
     config: JsonSchemaConfig,
-) : AbstractSchemaGenerator<KSerializer<*>, JsonSchema>(
+) : AbstractSchemaGenerator<SerialDescriptor, JsonSchema>(
         introspector = SerializationClassSchemaIntrospector(json),
         typeGraphTransformer =
             TypeGraphToJsonSchemaTransformer(
@@ -39,9 +39,9 @@ public class SerializationClassJsonSchemaGenerator(
         config = JsonSchemaConfig.Default,
     )
 
-    override fun getRootName(target: KSerializer<*>): String = target.descriptor.serialName
+    override fun getRootName(target: SerialDescriptor): String = target.serialName
 
-    override fun targetType(): KClass<KSerializer<*>> = KSerializer::class
+    override fun targetType(): KClass<SerialDescriptor> = SerialDescriptor::class
 
     override fun schemaType(): KClass<JsonSchema> = JsonSchema::class
 
@@ -52,9 +52,9 @@ public class SerializationClassJsonSchemaGenerator(
          * A default instance of the [SerializationClassJsonSchemaGenerator] class, preconfigured
          * with the default settings defined in [JsonSchemaConfig.Default].
          *
-         * This instance can be used to generate JSON schema representations of Kotlin
-         * objects using reflection-based introspection. It simplifies the creation
-         * of schemas without requiring explicit configuration.
+         * This instance can be used to generate JSON schema representations from
+         * kotlinx.serialization descriptors. It simplifies the creation of schemas
+         * without requiring explicit configuration.
          */
         public val Default: SerializationClassJsonSchemaGenerator =
             SerializationClassJsonSchemaGenerator(

--- a/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassSchemaIntrospector.kt
+++ b/kotlinx-schema-generator-json/src/main/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassSchemaIntrospector.kt
@@ -2,14 +2,14 @@ package kotlinx.schema.generator.json.serialization
 
 import kotlinx.schema.generator.core.ir.SchemaIntrospector
 import kotlinx.schema.generator.core.ir.TypeGraph
-import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.json.Json
 
 /**
  * Introspects kotlinx.serialization descriptors into Schema IR.
  *
  * This introspector uses [SerializationIntrospectionContext] to convert
- * kotlinx.serialization [KSerializer] descriptors into the Schema IR type system.
+ * kotlinx.serialization [SerialDescriptor] instances into the Schema IR type system.
  *
  * @property json The Json configuration used to extract discriminator settings for polymorphic types.
  *                Defaults to a Json instance with encodeDefaults = false.
@@ -20,16 +20,16 @@ public class SerializationClassSchemaIntrospector(
         classDiscriminator = "type"
         classDiscriminatorMode = kotlinx.serialization.json.ClassDiscriminatorMode.ALL_JSON_OBJECTS
     },
-) : SchemaIntrospector<KSerializer<*>> {
+) : SchemaIntrospector<SerialDescriptor> {
     /**
-     * Introspects a serializer's descriptor into a [TypeGraph].
+     * Introspects a serial descriptor into a [TypeGraph].
      *
-     * @param root The root serializer to introspect
+     * @param root The root serial descriptor to introspect
      * @return A TypeGraph containing the root type reference and all discovered type nodes
      */
-    public override fun introspect(root: KSerializer<*>): TypeGraph {
+    public override fun introspect(root: SerialDescriptor): TypeGraph {
         val context = SerializationIntrospectionContext(json)
-        val rootRef = context.toRef(root.descriptor)
+        val rootRef = context.toRef(root)
         return TypeGraph(root = rootRef, nodes = context.nodes())
     }
 }

--- a/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGeneratorTest.kt
@@ -5,11 +5,9 @@ import kotlinx.schema.Description
 import kotlinx.schema.generator.core.SchemaGeneratorService
 import kotlinx.schema.json.JsonSchema
 import kotlinx.schema.json.encodeToString
-import kotlinx.serialization.InternalSerializationApi
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.serializer
 import kotlin.test.Test
 
 class SerializationClassJsonSchemaGeneratorTest {
@@ -38,17 +36,16 @@ class SerializationClassJsonSchemaGeneratorTest {
         """
 
     val generator =
-        SchemaGeneratorService.getGenerator(KSerializer::class, JsonSchema::class)
+        SchemaGeneratorService.getGenerator(SerialDescriptor::class, JsonSchema::class)
             ?: error(
                 "SerializationClassJsonSchemaGenerator must be registered",
             )
 
-    @OptIn(InternalSerializationApi::class)
     @Test
-    fun generateJsonSchema() {
+    fun `Should generate JsonSchema from SerialDescriptor`() {
         val schema =
             generator.generateSchema(
-                Person::class.serializer(),
+                Person.serializer().descriptor,
             )
 
         val actualSchemaJson = schema.encodeToString(Json)

--- a/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
+++ b/kotlinx-schema-generator-json/src/test/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
@@ -63,8 +63,8 @@ class SerializationIntrospectorTest {
     @Test
     @Suppress("LongMethod")
     fun `introspects object with primitives list map nullability and defaults`() {
-        val kser = serializer<User>()
-        val graph = introspector.introspect(kser)
+        val descriptor = serializer<User>().descriptor
+        val graph = introspector.introspect(descriptor)
 
         // Root must be a ref to the User id (serial name)
         val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
@@ -145,7 +145,7 @@ class SerializationIntrospectorTest {
 
     @Test
     fun `introspects enum and adds node with entries and description`() {
-        val graph = introspector.introspect(WithEnum.serializer())
+        val graph = introspector.introspect(WithEnum.serializer().descriptor)
 
         val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
         val withEnumNode = graph.nodes[rootRef.id].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
@@ -158,7 +158,7 @@ class SerializationIntrospectorTest {
 
     @Test
     fun `introspects sealed polymorphic adds polymorphic node and subtype objects`() {
-        val graph = introspector.introspect(Shape.serializer())
+        val graph = introspector.introspect(Shape.serializer().descriptor)
 
         val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
         val polyNode = graph.nodes[rootRef.id].shouldNotBeNull().shouldBeInstanceOf<PolymorphicNode>()


### PR DESCRIPTION
# Replace `KSerializer` with `SerialDescriptor` for JSON Schema generation (#84)

- Updated `SerializationClassJsonSchemaGenerator` and `SerializationClassSchemaIntrospector` to use `SerialDescriptor` instead of `KSerializer`.
- Refactored related methods (e.g., `getRootName`, `introspect`, test cases) to align with the new API.
- Adjusted architecture docs and diagrams to reflect the transition.


### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements
