### PR TITLE
feat(ksp): Extract parameter, field and property descriptions from KDoc (#109)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ Each module must have a `Module.md` file at the module root for Dokka-generated 
 
 - Build all modules: `./gradlew build`
 - Run all tests: `./gradlew test`
-- KSP integration tests: `./gradlew :ksp-integration-tests:test`
+- KSP integration tests: `make integration-test`
 
 ## When to ask for help
 

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspFunctionIntrospector.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspFunctionIntrospector.kt
@@ -42,8 +42,15 @@ internal class KspFunctionIntrospector : SchemaIntrospector<KSFunctionDeclaratio
 
             val typeRef = context.toRef(paramType)
 
-            // Extract description from annotations or KDoc
-            val description = extractDescription(param) { null }
+            // Extract description from annotations, then fall back to function KDoc @param tag
+            val description =
+                extractPropertyDescription(
+                    annotated = param,
+                    propertyName = paramName,
+                    parentKdoc = root.docString,
+                    kdocTagName = "param",
+                    elementKdocFallback = { null },
+                )
 
             // KSP limitation: hasDefault doesn't reliably detect default values in the same compilation unit
             // For function calling schemas, all parameters are marked as required by default (including nullable)

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/kdoc.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/kdoc.kt
@@ -21,3 +21,86 @@ internal fun extractDescriptionFromKdoc(kdoc: String?): String? =
         ?.joinToString("\n")
         // Normalize empty result to null
         ?.ifBlank { null }
+
+/**
+ * Extracts the description for a specific parameter from KDoc.
+ *
+ * Searches for `@param <paramName>` tag and returns its description.
+ * Supports multi-line descriptions that continue until the next tag or end of KDoc.
+ *
+ * @param kdoc The KDoc string to parse
+ * @param paramName The name of the parameter to find
+ * @return The parameter description or null if not found
+ */
+internal fun extractParamDescriptionFromKdoc(
+    kdoc: String?,
+    paramName: String,
+): String? = extractTagDescriptionFromKdoc(kdoc, "param", paramName)
+
+/**
+ * Extracts the description for a specific property from KDoc.
+ *
+ * Searches for `@property <propertyName>` tag and returns its description.
+ * Supports multi-line descriptions that continue until the next tag or end of KDoc.
+ *
+ * @param kdoc The KDoc string to parse
+ * @param propertyName The name of the property to find
+ * @return The property description or null if not found
+ */
+internal fun extractPropertyDescriptionFromKdoc(
+    kdoc: String?,
+    propertyName: String,
+): String? = extractTagDescriptionFromKdoc(kdoc, "property", propertyName)
+
+/**
+ * Generic function to extract description for a specific KDoc tag.
+ *
+ * @param kdoc The KDoc string to parse
+ * @param tagName The tag name (e.g., "param", "property")
+ * @param targetName The name of the parameter/property to find
+ * @return The tag description or null if not found
+ */
+internal fun extractTagDescriptionFromKdoc(
+    kdoc: String?,
+    tagName: String,
+    targetName: String,
+): String? =
+    kdoc
+        ?.lineSequence()
+        ?.map { it.trim() }
+        ?.toList()
+        ?.let { lines ->
+            val tagPrefix = "@$tagName"
+
+            // Find the line with the target tag
+            val targetIndex =
+                lines.indexOfFirst { line ->
+                    if (!line.startsWith(tagPrefix)) return@indexOfFirst false
+                    val tagContent = line.removePrefix(tagPrefix).trim()
+                    val paramName = tagContent.takeWhile { !it.isWhitespace() }
+                    paramName == targetName
+                }
+
+            if (targetIndex == -1) return@let null
+
+            // Extract description from the tag line and continuation lines
+            val firstLine = lines[targetIndex]
+            val tagContent = firstLine.removePrefix(tagPrefix).trim()
+            val paramName = tagContent.takeWhile { !it.isWhitespace() }
+            val descriptionStart = tagContent.drop(paramName.length).trim()
+
+            buildString {
+                if (descriptionStart.isNotBlank()) append(descriptionStart)
+
+                // Collect continuation lines until the next tag
+                lines
+                    .asSequence()
+                    .drop(targetIndex + 1)
+                    .takeWhile { !it.startsWith("@") }
+                    .filter { it.isNotBlank() }
+                    .forEach { line ->
+                        if (isNotEmpty()) append('\n')
+                        append(line)
+                    }
+            }.ifBlank { null }
+        }

--- a/kotlinx-schema-ksp/src/test/kotlin/kotlinx/schema/ksp/ir/KdocDescriptionTest.kt
+++ b/kotlinx-schema-ksp/src/test/kotlin/kotlinx/schema/ksp/ir/KdocDescriptionTest.kt
@@ -120,4 +120,172 @@ class KdocDescriptionTest {
         val result = extractDescriptionFromKdoc(kdoc)
         result shouldBe "First line\nSecond line\nThird line\nFourth line"
     }
+
+    @Test
+    fun `Should extract param description from single line tag`() {
+        val kdoc =
+            """
+            |Function description
+            |
+            |@param name User name to search
+            |@param age User age
+            """.trimMargin()
+
+        val result = extractParamDescriptionFromKdoc(kdoc, "name")
+        result shouldBe "User name to search"
+    }
+
+    @Test
+    fun `Should extract param description from multi-line tag`() {
+        val kdoc =
+            """
+            |Function description
+            |
+            |@param name User name to search.
+            |            This can be a full name or partial match.
+            |            Case insensitive.
+            |@param age User age
+            """.trimMargin()
+
+        val result = extractParamDescriptionFromKdoc(kdoc, "name")
+        result shouldBe "User name to search.\nThis can be a full name or partial match.\nCase insensitive."
+    }
+
+    @Test
+    fun `Should return null for non-existent param`() {
+        val kdoc =
+            """
+            |@param name User name
+            |@param age User age
+            """.trimMargin()
+
+        val result = extractParamDescriptionFromKdoc(kdoc, "email")
+        result shouldBe null
+    }
+
+    @Test
+    fun `Should return null for param with null kdoc`() {
+        val result = extractParamDescriptionFromKdoc(null, "name")
+        result shouldBe null
+    }
+
+    @Test
+    fun `Should handle param tag with no description`() {
+        val kdoc =
+            """
+            |@param name
+            |@param age User age
+            """.trimMargin()
+
+        val result = extractParamDescriptionFromKdoc(kdoc, "name")
+        result shouldBe null
+    }
+
+    @Test
+    fun `Should extract property description from single line tag`() {
+        val kdoc =
+            """
+            |Data class description
+            |
+            |@property name User name
+            |@property age User age
+            """.trimMargin()
+
+        val result = extractPropertyDescriptionFromKdoc(kdoc, "name")
+        result shouldBe "User name"
+    }
+
+    @Test
+    fun `Should extract property description from multi-line tag`() {
+        val kdoc =
+            """
+            |Data class description
+            |
+            |@property address User's full address.
+            |                  Including street, city, and postal code.
+            |                  Required for shipping.
+            """.trimMargin()
+
+        val result = extractPropertyDescriptionFromKdoc(kdoc, "address")
+        result shouldBe "User's full address.\nIncluding street, city, and postal code.\nRequired for shipping."
+    }
+
+    @Test
+    fun `Should return null for non-existent property`() {
+        val kdoc =
+            """
+            |@property name User name
+            |@property age User age
+            """.trimMargin()
+
+        val result = extractPropertyDescriptionFromKdoc(kdoc, "email")
+        result shouldBe null
+    }
+
+    @Test
+    fun `Should return null for property with null kdoc`() {
+        val result = extractPropertyDescriptionFromKdoc(null, "name")
+        result shouldBe null
+    }
+
+    @Test
+    fun `Should handle property tag with no description`() {
+        val kdoc =
+            """
+            |@property name
+            |@property age User age
+            """.trimMargin()
+
+        val result = extractPropertyDescriptionFromKdoc(kdoc, "name")
+        result shouldBe null
+    }
+
+    @Test
+    fun `Should extract param description ignoring indentation`() {
+        val kdoc =
+            """
+            |    @param name     User name with extra spaces
+            |    @param age User age
+            """.trimMargin()
+
+        val result = extractParamDescriptionFromKdoc(kdoc, "name")
+        result shouldBe "User name with extra spaces"
+    }
+
+    @Test
+    fun `Should stop at next tag when extracting param description`() {
+        val kdoc =
+            """
+            |@param name User name
+            |        More details about name
+            |@param age User age
+            """.trimMargin()
+
+        val result = extractParamDescriptionFromKdoc(kdoc, "name")
+        result shouldBe "User name\nMore details about name"
+    }
+
+    @Test
+    fun `Should match exact parameter name not prefix`() {
+        val kdoc =
+            """
+            |@param name Full name
+            |@param namePrefix Just prefix
+            """.trimMargin()
+
+        extractParamDescriptionFromKdoc(kdoc, "name") shouldBe "Full name"
+        extractParamDescriptionFromKdoc(kdoc, "namePrefix") shouldBe "Just prefix"
+    }
+
+    @Test
+    fun `Should match exact property name not prefix`() {
+        val kdoc =
+            """
+            |@property id User ID
+            |@property identifier Full identifier
+            """.trimMargin()
+
+        extractPropertyDescriptionFromKdoc(kdoc, "id") shouldBe "User ID"
+        extractPropertyDescriptionFromKdoc(kdoc, "identifier") shouldBe "Full identifier"
+    }
 }

--- a/ksp-integration-tests/src/main/kotlin/kotlinx/schema/integration/kdoc/KDocParameters.kt
+++ b/ksp-integration-tests/src/main/kotlin/kotlinx/schema/integration/kdoc/KDocParameters.kt
@@ -1,0 +1,130 @@
+@file:Suppress("unused", "UnusedParameter")
+
+package kotlinx.schema.integration.kdoc
+
+import kotlinx.schema.Schema
+
+/**
+ * Searches for users by name and age.
+ *
+ * @param name User name to search for
+ * @param age User age filter
+ * @param includeInactive Whether to include inactive users in results
+ */
+@Schema
+fun searchUsers(
+    name: String,
+    age: Int?,
+    includeInactive: Boolean = false,
+): String = "Searching for $name, age $age"
+
+/**
+ * Creates a new user account.
+ *
+ * This function creates a new user with the provided details.
+ * It validates the email and ensures the username is unique.
+ *
+ * @param username Unique username for the account
+ * @param email User's email address.
+ *              Must be a valid email format.
+ * @param age User's age in years
+ */
+@Schema
+fun createUser(
+    username: String,
+    email: String,
+    age: Int,
+): String = "User created: $username"
+
+/**
+ * User profile with basic information.
+ *
+ * @property id Unique user identifier
+ * @property name Full name of the user
+ * @property email Email address for notifications
+ */
+@Schema
+data class UserProfile(
+    val id: String,
+    val name: String,
+    val email: String,
+)
+
+/**
+ * Configuration for the application.
+ *
+ * @property apiKey API key for authentication
+ * @property timeout Connection timeout in milliseconds
+ * @property retries Number of retry attempts
+ */
+@Schema
+data class AppConfig(
+    val apiKey: String,
+    val timeout: Int = 5000,
+    val retries: Int = 3,
+)
+
+/**
+ * Product information.
+ *
+ * @param name Product name
+ * @param price Price in USD
+ * @param category Product category
+ */
+@Schema
+data class Product(
+    val name: String,
+    val price: Double,
+    val category: String,
+)
+
+/**
+ * Updates user settings.
+ *
+ * @param userId ID of the user to update
+ * @param settings Map of settings to update
+ */
+@Schema
+suspend fun updateUserSettings(
+    userId: String,
+    settings: Map<String, String>,
+): Boolean {
+    kotlinx.coroutines.delay(1)
+    return true
+}
+
+/**
+ * Response with mixed description sources.
+ *
+ * Demonstrates fallback chain: annotation > @param tag > @property tag
+ *
+ * @param statusCode HTTP status code
+ * @property data Response payload from @property tag
+ */
+@Schema
+data class ApiResponse(
+    @kotlinx.schema.Description("Response message from annotation")
+    val message: String,
+    val statusCode: Int,
+    val data: String,
+)
+
+/**
+ * Class with properties declared in body (fields).
+ *
+ * Demonstrates field-level KDoc extraction.
+ *
+ * @property computed Computed from class KDoc @property tag
+ */
+@Schema
+class FieldsExample {
+    /**
+     * Field with its own KDoc.
+     */
+    val id: String = "default-id"
+
+    val name: String = "default-name"
+
+    @Suppress("MagicNumber")
+    val computed: Int = 42
+}

--- a/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/kdoc/KDocParametersTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/kdoc/KDocParametersTest.kt
@@ -1,0 +1,280 @@
+@file:Suppress("JsonStandardCompliance")
+
+package kotlinx.schema.integration.kdoc
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlin.test.Test
+
+/**
+ * Integration tests for KDoc parameter and property description extraction.
+ *
+ * Tests verify that:
+ * - Function parameters with @param KDoc tags get descriptions
+ * - Class properties with @property KDoc tags get descriptions
+ * - Multi-line parameter descriptions are correctly extracted
+ * - Descriptions fallback from annotations -> property KDoc -> class KDoc
+ */
+class KDocParametersTest {
+    @Test
+    fun `searchUsers function extracts param descriptions from KDoc`() {
+        val schema = searchUsersJsonSchemaString()
+
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "searchUsers",
+              "description": "Searches for users by name and age.",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "User name to search for"
+                  },
+                  "age": {
+                    "type": ["integer", "null"],
+                    "description": "User age filter"
+                  },
+                  "includeInactive": {
+                    "type": "boolean",
+                    "description": "Whether to include inactive users in results"
+                  }
+                },
+                "required": ["name", "age", "includeInactive"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `createUser function extracts multi-line param descriptions from KDoc`() {
+        val schema = createUserJsonSchemaString()
+
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "createUser",
+              "description": "Creates a new user account.\nThis function creates a new user with the provided details.\nIt validates the email and ensures the username is unique.",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "description": "Unique username for the account"
+                  },
+                  "email": {
+                    "type": "string",
+                    "description": "User's email address.\nMust be a valid email format."
+                  },
+                  "age": {
+                    "type": "integer",
+                    "description": "User's age in years"
+                  }
+                },
+                "required": ["username", "email", "age"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `UserProfile class extracts property descriptions from KDoc`() {
+        val schema = UserProfile::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.integration.kdoc.UserProfile",
+              "description": "User profile with basic information.",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique user identifier"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Full name of the user"
+                },
+                "email": {
+                  "type": "string",
+                  "description": "Email address for notifications"
+                }
+              },
+              "required": ["id", "name", "email"],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `AppConfig class extracts property descriptions from KDoc with defaults`() {
+        val schema = AppConfig::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.integration.kdoc.AppConfig",
+              "description": "Configuration for the application.",
+              "type": "object",
+              "properties": {
+                "apiKey": {
+                  "type": "string",
+                  "description": "API key for authentication"
+                },
+                "timeout": {
+                  "type": "integer",
+                  "description": "Connection timeout in milliseconds"
+                },
+                "retries": {
+                  "type": "integer",
+                  "description": "Number of retry attempts"
+                }
+              },
+              "required": ["apiKey", "timeout", "retries"],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `Product class extracts descriptions from @param KDoc tags`() {
+        val schema = Product::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.integration.kdoc.Product",
+              "description": "Product information.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Product name"
+                },
+                "price": {
+                  "type": "number",
+                  "description": "Price in USD"
+                },
+                "category": {
+                  "type": "string",
+                  "description": "Product category"
+                }
+              },
+              "required": ["name", "price", "category"],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `updateUserSettings suspend function extracts param descriptions from KDoc`() {
+        val schema = updateUserSettingsJsonSchemaString()
+
+        // language=json
+        schema shouldEqualJson
+            """
+            {
+              "type": "function",
+              "name": "updateUserSettings",
+              "description": "Updates user settings.",
+              "strict": true,
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string",
+                    "description": "ID of the user to update"
+                  },
+                  "settings": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Map of settings to update"
+                  }
+                },
+                "required": ["userId", "settings"],
+                "additionalProperties": false
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `ApiResponse demonstrates description fallback chain`() {
+        val schema = ApiResponse::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.integration.kdoc.ApiResponse",
+              "description": "Response with mixed description sources.\nDemonstrates fallback chain: annotation > @param tag > @property tag",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "description": "Response message from annotation"
+                },
+                "statusCode": {
+                  "type": "integer",
+                  "description": "HTTP status code"
+                },
+                "data": {
+                  "type": "string",
+                  "description": "Response payload from @property tag"
+                }
+              },
+              "required": ["message", "statusCode", "data"],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `FieldsExample extracts descriptions from field KDoc and class KDoc`() {
+        val schema = FieldsExample::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.integration.kdoc.FieldsExample",
+              "description": "Class with properties declared in body (fields).\nDemonstrates field-level KDoc extraction.",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Field with its own KDoc."
+                },
+                "name": {
+                  "type": "string"
+                },
+                "computed": {
+                  "type": "integer",
+                  "description": "Computed from class KDoc @property tag"
+                }
+              },
+              "required": ["id", "name", "computed"],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+}


### PR DESCRIPTION
# Add support for extracting parameter, field and property descriptions from KDoc (#109)

- Introduced `extractParamDescriptionFromKdoc` and `extractPropertyDescriptionFromKdoc` for parsing `@param` and `@property` tags, including multiline descriptions.
- Enhanced description extraction with fallback chains: annotations -> parameter KDoc -> parent KDoc.
- Updated introspector logic to use new KDoc extractors for constructor parameters and properties.
- Added integration and unit tests for KDoc-based description extraction, covering single-line and multi-line cases.

**Related Issues:** Fixes #109 

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements

