### PR TITLE
feat(json): add config to SchemaIntrospector, implement custom annotation description extraction for SerializationClassJsonSchemaGenerator

### DIFF
--- a/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/AbstractSchemaGenerator.kt
+++ b/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/AbstractSchemaGenerator.kt
@@ -8,12 +8,13 @@ import kotlinx.schema.generator.core.ir.TypeGraphTransformer
  *
  * @param T the type of the object for which the schema is being generated
  * @param R the type of the resulting schema representation
+ * @param C the type of the configuration used by the introspector
  * @property introspector the component responsible for introspecting the input and producing a type graph
  * @property typeGraphTransformer the component responsible for converting the type graph
  * into the desired schema representation
  */
-public abstract class AbstractSchemaGenerator<T : Any, R : Any>(
-    protected val introspector: SchemaIntrospector<T>,
+public abstract class AbstractSchemaGenerator<T : Any, R : Any, C : Any>(
+    protected val introspector: SchemaIntrospector<T, C>,
     protected val typeGraphTransformer: TypeGraphTransformer<R, *>,
 ) : SchemaGenerator<T, R> {
     protected abstract fun getRootName(target: T): String

--- a/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/ir/Introspections.kt
+++ b/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/ir/Introspections.kt
@@ -114,3 +114,18 @@ public object Introspections {
             null
         }
 }
+
+/**
+ * Functional interface describing a strategy for extracting a property/type description from a list of annotations
+ * associated with it.
+ * It's used to allow custom description annotations.
+ */
+public fun interface DescriptionExtractor {
+    /**
+     * Extracts a description from a list of annotations.
+     *
+     * @param annotations List of annotations to inspect for a description
+     * @return The description text if found, or null if no description is present
+     */
+    public fun extract(annotations: List<Annotation>): String?
+}

--- a/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/ir/SchemaIntrospector.kt
+++ b/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/ir/SchemaIntrospector.kt
@@ -12,6 +12,11 @@ package kotlinx.schema.generator.core.ir
  * 5. Introspectors instantiate context and call `toRef()` / `convertToTypeRef()`
  * 6. Return TypeGraph(root, context.nodes)
  */
-public interface SchemaIntrospector<T> {
+public interface SchemaIntrospector<T, C> {
+    /**
+     * Configuration object for the introspector
+     */
+    public val config: C
+
     public fun introspect(root: T): TypeGraph
 }

--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionClassIntrospector.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionClassIntrospector.kt
@@ -29,7 +29,9 @@ import kotlin.reflect.KProperty
  * - Requires classes to have a primary constructor
  * - Type parameters are not fully supported
  */
-public object ReflectionClassIntrospector : SchemaIntrospector<KClass<*>> {
+public object ReflectionClassIntrospector : SchemaIntrospector<KClass<*>, Unit> {
+    override val config: Unit = Unit
+
     override fun introspect(root: KClass<*>): TypeGraph {
         val context = IntrospectionContext()
         val rootRef = context.convertToTypeRef(root)

--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionFunctionIntrospector.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionFunctionIntrospector.kt
@@ -22,7 +22,9 @@ import kotlin.reflect.KParameter
  * val typeGraph = ReflectionFunctionIntrospector.introspect(::myFunction)
  * ```
  */
-public object ReflectionFunctionIntrospector : SchemaIntrospector<KCallable<*>> {
+public object ReflectionFunctionIntrospector : SchemaIntrospector<KCallable<*>, Unit> {
+    override val config: Unit = Unit
+
     override fun introspect(root: KCallable<*>): TypeGraph {
         require(!root.isSuspend) { "Suspend functions are not supported" }
         require(root.parameters.none { it.kind == KParameter.Kind.EXTENSION_RECEIVER }) {

--- a/kotlinx-schema-generator-core/src/jvmTest/kotlin/kotlinx/schema/generator/core/AbstractSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-core/src/jvmTest/kotlin/kotlinx/schema/generator/core/AbstractSchemaGeneratorTest.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KClass
 @ExtendWith(MockKExtension::class)
 class AbstractSchemaGeneratorTest {
     @MockK
-    private lateinit var introspector: SchemaIntrospector<KClass<*>>
+    private lateinit var introspector: SchemaIntrospector<KClass<*>, Unit>
 
     @MockK
     private lateinit var emitter: TypeGraphTransformer<Map<String, String>, *>
@@ -23,14 +23,14 @@ class AbstractSchemaGeneratorTest {
     @MockK
     private lateinit var typeGraph: TypeGraph
 
-    private lateinit var generator: AbstractSchemaGenerator<KClass<*>, Map<String, String>>
+    private lateinit var generator: AbstractSchemaGenerator<KClass<*>, Map<String, String>, Unit>
 
     private val rootName = AbstractSchemaGeneratorTest::class.qualifiedName!!
 
     @BeforeEach
     fun setUp() {
         generator =
-            object : AbstractSchemaGenerator<KClass<*>, Map<String, String>>(introspector, emitter) {
+            object : AbstractSchemaGenerator<KClass<*>, Map<String, String>, Unit>(introspector, emitter) {
                 override fun getRootName(target: KClass<*>): String = requireNotNull(target.qualifiedName)
 
                 override fun targetType(): KClass<KClass<*>> = KClass::class

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGenerator.kt
@@ -16,29 +16,28 @@ import kotlin.reflect.KClass
  * with a configurable `JsonSchemaConfig` to define schema generation behavior.
  *
  * @constructor Creates an instance of `SerializationClassJsonSchemaGenerator`.
- * @param config Configuration for generating JSON Schemas, such as formatting details
+ * @param json The [Json] instance used for serializing schema objects.
+ * @param introspectorConfig Configuration for introspecting serial descriptors.
+ * @param jsonSchemaConfig Configuration for generating JSON Schemas, such as formatting details
  * and handling of optional nullable properties. Defaults to [JsonSchemaConfig.Default].
  */
 public class SerializationClassJsonSchemaGenerator(
-    private val json: Json,
-    config: JsonSchemaConfig,
-) : AbstractSchemaGenerator<SerialDescriptor, JsonSchema>(
-        introspector = SerializationClassSchemaIntrospector(json),
-        typeGraphTransformer =
-            TypeGraphToJsonSchemaTransformer(
-                config = config,
-                json = json,
-            ),
-    ) {
-    public constructor() : this(
-        json = Json {
+    private val json: Json =
+        Json {
             encodeDefaults = false
             classDiscriminator = "type"
             classDiscriminatorMode = kotlinx.serialization.json.ClassDiscriminatorMode.ALL_JSON_OBJECTS
         },
-        config = JsonSchemaConfig.Default,
-    )
-
+    introspectorConfig: SerializationClassSchemaIntrospector.Config = SerializationClassSchemaIntrospector.Config(),
+    jsonSchemaConfig: JsonSchemaConfig = JsonSchemaConfig.Default,
+) : AbstractSchemaGenerator<SerialDescriptor, JsonSchema, SerializationClassSchemaIntrospector.Config>(
+        introspector = SerializationClassSchemaIntrospector(introspectorConfig, json),
+        typeGraphTransformer =
+            TypeGraphToJsonSchemaTransformer(
+                config = jsonSchemaConfig,
+                json = json,
+            ),
+    ) {
     override fun getRootName(target: SerialDescriptor): String = target.serialName
 
     override fun targetType(): KClass<SerialDescriptor> = SerialDescriptor::class
@@ -56,14 +55,6 @@ public class SerializationClassJsonSchemaGenerator(
          * kotlinx.serialization descriptors. It simplifies the creation of schemas
          * without requiring explicit configuration.
          */
-        public val Default: SerializationClassJsonSchemaGenerator =
-            SerializationClassJsonSchemaGenerator(
-                json = Json {
-                    encodeDefaults = false
-                    classDiscriminator = "type"
-                    classDiscriminatorMode = kotlinx.serialization.json.ClassDiscriminatorMode.ALL_JSON_OBJECTS
-                },
-                config = JsonSchemaConfig.Default,
-            )
+        public val Default: SerializationClassJsonSchemaGenerator = SerializationClassJsonSchemaGenerator()
     }
 }

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassSchemaIntrospector.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassSchemaIntrospector.kt
@@ -1,5 +1,6 @@
 package kotlinx.schema.generator.json.serialization
 
+import kotlinx.schema.generator.core.ir.DescriptionExtractor
 import kotlinx.schema.generator.core.ir.SchemaIntrospector
 import kotlinx.schema.generator.core.ir.TypeGraph
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -15,12 +16,18 @@ import kotlinx.serialization.json.Json
  *                Defaults to a Json instance with encodeDefaults = false.
  */
 public class SerializationClassSchemaIntrospector(
-    private val json: Json = Json {
-        encodeDefaults = false
-        classDiscriminator = "type"
-        classDiscriminatorMode = kotlinx.serialization.json.ClassDiscriminatorMode.ALL_JSON_OBJECTS
-    },
-) : SchemaIntrospector<SerialDescriptor> {
+    override val config: Config = Config(),
+    private val json: Json =
+        Json {
+            encodeDefaults = false
+            classDiscriminator = "type"
+            classDiscriminatorMode = kotlinx.serialization.json.ClassDiscriminatorMode.ALL_JSON_OBJECTS
+        },
+) : SchemaIntrospector<SerialDescriptor, SerializationClassSchemaIntrospector.Config> {
+    public data class Config(
+        val descriptionExtractor: DescriptionExtractor = DescriptionExtractor { null },
+    )
+
     /**
      * Introspects a serial descriptor into a [TypeGraph].
      *
@@ -28,7 +35,7 @@ public class SerializationClassSchemaIntrospector(
      * @return A TypeGraph containing the root type reference and all discovered type nodes
      */
     public override fun introspect(root: SerialDescriptor): TypeGraph {
-        val context = SerializationIntrospectionContext(json)
+        val context = SerializationIntrospectionContext(json, config)
         val rootRef = context.toRef(root)
         return TypeGraph(root = rootRef, nodes = context.nodes())
     }

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -36,6 +36,7 @@ import kotlinx.serialization.descriptors.PrimitiveKind as SerialPrimitiveKind
 @OptIn(InternalSchemaGeneratorApi::class)
 internal class SerializationIntrospectionContext(
     private val json: Json,
+    private val config: SerializationClassSchemaIntrospector.Config,
 ) : BaseIntrospectionContext<SerialDescriptor, SerialDescriptor>() {
     /**
      * Returns the discovered type nodes.
@@ -356,26 +357,18 @@ internal class SerializationIntrospectionContext(
     private fun descriptorId(descriptor: SerialDescriptor): TypeId = TypeId(descriptor.serialName)
 
     /**
-     * Extracts the @Description annotation value from a descriptor's annotations.
+     * Extracts description from a list of type annotations.
      */
     private fun extractDescription(descriptor: SerialDescriptor): String? =
-        descriptor.annotations
-            .filterIsInstance<Description>()
-            .firstOrNull()
-            ?.value
+        config.descriptionExtractor.extract(descriptor.annotations)
 
     /**
-     * Extracts the @Description annotation value from a descriptor element's annotations.
+     * Extracts description from a list of element annotations.
      */
     private fun extractElementDescription(
         descriptor: SerialDescriptor,
         index: Int,
-    ): String? =
-        descriptor
-            .getElementAnnotations(index)
-            .filterIsInstance<Description>()
-            .firstOrNull()
-            ?.value
+    ): String? = config.descriptionExtractor.extract(descriptor.getElementAnnotations(index))
 
     /**
      * Returns a new [TypeRef] with the specified nullable flag.

--- a/kotlinx-schema-generator-json/src/jvmMain/kotlin/kotlinx/schema/generator/json/ReflectionClassJsonObjectSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/jvmMain/kotlin/kotlinx/schema/generator/json/ReflectionClassJsonObjectSchemaGenerator.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.KClass
 public class ReflectionClassJsonObjectSchemaGenerator(
     private val json: Json,
     config: JsonSchemaConfig,
-) : AbstractSchemaGenerator<KClass<out Any>, JsonObject>(
+) : AbstractSchemaGenerator<KClass<out Any>, JsonObject, Unit>(
         introspector = ReflectionClassIntrospector,
         typeGraphTransformer =
             TypeGraphToJsonObjectSchemaTransformer(

--- a/kotlinx-schema-generator-json/src/jvmMain/kotlin/kotlinx/schema/generator/json/ReflectionClassJsonSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/jvmMain/kotlin/kotlinx/schema/generator/json/ReflectionClassJsonSchemaGenerator.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
 public class ReflectionClassJsonSchemaGenerator(
     private val json: Json,
     config: JsonSchemaConfig,
-) : AbstractSchemaGenerator<KClass<out Any>, JsonSchema>(
+) : AbstractSchemaGenerator<KClass<out Any>, JsonSchema, Unit>(
         introspector = ReflectionClassIntrospector,
         typeGraphTransformer =
             TypeGraphToJsonSchemaTransformer(

--- a/kotlinx-schema-generator-json/src/jvmMain/kotlin/kotlinx/schema/generator/json/ReflectionFunctionCallingSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/jvmMain/kotlin/kotlinx/schema/generator/json/ReflectionFunctionCallingSchemaGenerator.kt
@@ -23,7 +23,7 @@ import kotlin.reflect.KClass
  */
 public class ReflectionFunctionCallingSchemaGenerator(
     private val json: Json,
-) : AbstractSchemaGenerator<KCallable<*>, FunctionCallingSchema>(
+) : AbstractSchemaGenerator<KCallable<*>, FunctionCallingSchema, Unit>(
         introspector = ReflectionFunctionIntrospector,
         typeGraphTransformer = TypeGraphToFunctionCallingSchemaTransformer(),
     ) {

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/generator/KspSchemaGeneratorConfig.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/generator/KspSchemaGeneratorConfig.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.KSerializer
  * @property jsonEncodeDefaults Whether to encode default values in the JSON output
  */
 internal data class KspSchemaGeneratorConfig<T : Any, R : Any>(
-    val introspector: SchemaIntrospector<T>,
+    val introspector: SchemaIntrospector<T, Unit>,
     val transformer: TypeGraphTransformer<R, *>,
     val serializer: KSerializer<R>,
     val jsonPrettyPrint: Boolean,

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/generator/UnifiedKspSchemaGenerator.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/generator/UnifiedKspSchemaGenerator.kt
@@ -48,7 +48,7 @@ import kotlin.reflect.KClass
  */
 internal class UnifiedKspSchemaGenerator<T : Any, R : Any>(
     private val config: KspSchemaGeneratorConfig<T, R>,
-) : AbstractSchemaGenerator<T, R>(
+) : AbstractSchemaGenerator<T, R, Unit>(
         introspector = config.introspector,
         typeGraphTransformer = config.transformer,
     ) {

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspClassIntrospector.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspClassIntrospector.kt
@@ -8,7 +8,9 @@ import kotlinx.schema.generator.core.ir.TypeRef
 /**
  * KSP-backed Schema IR introspector. Focuses on classes and enums; generics use star-projection.
  */
-internal class KspClassIntrospector : SchemaIntrospector<KSClassDeclaration> {
+internal class KspClassIntrospector : SchemaIntrospector<KSClassDeclaration, Unit> {
+    override val config = Unit
+
     override fun introspect(root: KSClassDeclaration): TypeGraph {
         val context = KspIntrospectionContext()
         val rootRef = TypeRef.Ref(root.typeId())

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspFunctionIntrospector.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspFunctionIntrospector.kt
@@ -24,7 +24,9 @@ import kotlinx.schema.generator.core.ir.TypeRef
  * Does NOT support:
  * - Lambda parameters with complex signatures
  */
-internal class KspFunctionIntrospector : SchemaIntrospector<KSFunctionDeclaration> {
+internal class KspFunctionIntrospector : SchemaIntrospector<KSFunctionDeclaration, Unit> {
+    override val config = Unit
+
     override fun introspect(root: KSFunctionDeclaration): TypeGraph {
         val context = KspIntrospectionContext()
 


### PR DESCRIPTION
## Description
Added generic `config` field to `SchemaIntrospector` interface to allow customizing schema introspection. Added `DescriptionExtractor` functional interface to allow customizing property/type description extraction logic. Added config for `SerializationClassSchemaIntrospector` to allow processing custom description annotations

**Related Issues:** closes #193 

