### PR TITLE
feat(json): consider constructor parameter annotations too when searching for property description with reflection generator

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-jvm-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm-convention.gradle.kts
@@ -30,3 +30,8 @@ kotlin {
 tasks.test {
     useJUnitPlatform()
 }
+
+tasks.withType<JavaCompile> {
+    // Preserve constructor parameter names in Java
+    options.compilerArgs.add("-parameters")
+}

--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-convention.gradle.kts
@@ -114,3 +114,8 @@ kotlin {
 tasks.named("detekt").configure {
     dependsOn("detektMainJvm", "detektTestJvm")
 }
+
+tasks.withType<JavaCompile> {
+    // Preserve constructor parameter names in Java
+    options.compilerArgs.add("-parameters")
+}

--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectionContext.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectionContext.kt
@@ -209,8 +209,8 @@ internal abstract class ReflectionIntrospectionContext : BaseIntrospectionContex
             val propertyName = param.name ?: return@forEach
             val hasDefault = param.isOptional
 
-            // Find the corresponding property to get annotations
-            val property = findPropertyByName(klass, propertyName)
+            // Get annotations both on the constructor parameter and property associated with it
+            val annotations = param.annotations + findPropertyByName(klass, propertyName)?.annotations.orEmpty()
 
             val propertyType = param.type
             val typeRef = convertKTypeToTypeRef(propertyType)
@@ -222,7 +222,7 @@ internal abstract class ReflectionIntrospectionContext : BaseIntrospectionContex
                 Property(
                     name = propertyName,
                     type = typeRef,
-                    description = property?.let { extractDescription(it.annotations) },
+                    description = extractDescription(annotations),
                     hasDefaultValue = hasDefault,
                     defaultValue = defaultValue,
                 )

--- a/kotlinx-schema-generator-json/src/jvmTest/java/kotlinx/schema/generator/test/JavaTestClass.java
+++ b/kotlinx-schema-generator-json/src/jvmTest/java/kotlinx/schema/generator/test/JavaTestClass.java
@@ -1,0 +1,49 @@
+package kotlinx.schema.generator.test;
+
+import kotlinx.schema.Description;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test class to verify that schema generation also works for Java classes based on their primary constructors
+ */
+@SuppressWarnings("unused")
+public class JavaTestClass {
+    public JavaTestClass(
+        @Description("A string property")
+        String stringProperty,
+        int intProperty,
+        long longProperty,
+        double doubleProperty,
+        float floatProperty,
+        Boolean booleanNullableProperty,
+        String nullableProperty,
+        List<String> listProperty,
+        Map<String, Integer> mapProperty,
+        NestedProperty nestedProperty,
+        List<NestedProperty> nestedListProperty,
+        Map<String, NestedProperty> nestedMapProperty,
+        TestEnum enumProperty
+    ) {}
+
+    @Description("Nested property class")
+    public static class NestedProperty {
+        public NestedProperty(
+            @Description("Nested foo property")
+            String foo,
+            int bar
+        ) {}
+    }
+
+    public enum TestEnum {
+        One,
+        Two
+    }
+
+    /**
+     * Java reflection class representing this class.
+     * Used for schema generation.
+     */
+    public static final Class<JavaTestClass> CLASS = JavaTestClass.class;
+}

--- a/kotlinx-schema-generator-json/src/jvmTest/kotlin/kotlinx/schema/generator/json/JavaClassJsonSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/jvmTest/kotlin/kotlinx/schema/generator/json/JavaClassJsonSchemaGeneratorTest.kt
@@ -1,0 +1,153 @@
+@file:Suppress("LongMethod")
+
+package kotlinx.schema.generator.json
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.schema.generator.test.JavaTestClass
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+
+class JavaClassJsonSchemaGeneratorTest {
+    private val generator =
+        ReflectionClassJsonSchemaGenerator(
+            json = Json { prettyPrint = true },
+            config = JsonSchemaConfig.Default,
+        )
+
+    @Test
+    fun `Should generate JsonSchema from Java class`() {
+        // External Java class
+        val actualSchema = generator.generateSchemaString(JavaTestClass.CLASS.kotlin)
+
+        // language=JSON
+        val expectedSchema =
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.generator.test.JavaTestClass",
+              "type": "object",
+              "properties": {
+                "stringProperty": {
+                  "type": "string",
+                  "description": "A string property"
+                },
+                "intProperty": {
+                  "type": "integer"
+                },
+                "longProperty": {
+                  "type": "integer"
+                },
+                "doubleProperty": {
+                  "type": "number"
+                },
+                "floatProperty": {
+                  "type": "number"
+                },
+                "booleanNullableProperty": {
+                  "type": "boolean"
+                },
+                "nullableProperty": {
+                  "type": "string"
+                },
+                "listProperty": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "mapProperty": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer"
+                  }
+                },
+                "nestedProperty": {
+                  "type": "object",
+                  "description": "Nested property class",
+                  "properties": {
+                    "foo": {
+                      "type": "string",
+                      "description": "Nested foo property"
+                    },
+                    "bar": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "foo",
+                    "bar"
+                  ],
+                  "additionalProperties": false
+                },
+                "nestedListProperty": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "description": "Nested property class",
+                    "properties": {
+                      "foo": {
+                        "type": "string",
+                        "description": "Nested foo property"
+                      },
+                      "bar": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "foo",
+                      "bar"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "nestedMapProperty": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "description": "Nested property class",
+                    "properties": {
+                      "foo": {
+                        "type": "string",
+                        "description": "Nested foo property"
+                      },
+                      "bar": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "foo",
+                      "bar"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "enumProperty": {
+                  "type": "string",
+                  "enum": [
+                    "One",
+                    "Two"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "stringProperty",
+                "intProperty",
+                "longProperty",
+                "doubleProperty",
+                "floatProperty",
+                "booleanNullableProperty",
+                "nullableProperty",
+                "listProperty",
+                "mapProperty",
+                "nestedProperty",
+                "nestedListProperty",
+                "nestedMapProperty",
+                "enumProperty"
+              ]
+            } 
+            """.trimIndent()
+
+        actualSchema shouldEqualJson expectedSchema
+    }
+}


### PR DESCRIPTION
## Description
Include constructor parameter annotations too along with the property annotations that are currently used. This correctly preserves descriptions when generating schemas from Java classes with "primary constructors" (see linked issue for an example).

Also added a simple schema generation test for a Java class.

**Related Issues:** closes #202 