### PR TITLE
fix(test): Add `gradleTestKit` to test dependencies in Gradle plugin configuration

### DIFF
--- a/kotlinx-schema-ksp-gradle-plugin/build.gradle.kts
+++ b/kotlinx-schema-ksp-gradle-plugin/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
 
     testRuntimeOnly(project(":kotlinx-schema-ksp"))
     testRuntimeOnly(project(":kotlinx-schema-annotations"))
+    testImplementation(gradleTestKit())
     testImplementation(libs.kotlin.test)
     testImplementation(libs.mockk)
     testImplementation(libs.kotest.assertions.core)


### PR DESCRIPTION
## Description

In Gradle 9.4, ProjectBuilder (from org.gradle.testfixtures) is no longer bundled into gradleApi() and must be explicitly requested via gradleTestKit(). Previously it leaked through transitively; now it doesn't.

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [ ] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [X] **No debug code**: Removed commented-out code and debug statements
