### PR TITLE
fix: Fix inline value class schema generation to match kotlinx-serialization format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,6 +285,7 @@ jobs:
 
   dependency-submission:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
 

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -80,6 +80,7 @@ internal class SerializationIntrospectionContext(
             }
 
             is StructureKind.CLASS, StructureKind.OBJECT -> {
+                if (type.isInline) return handleInlineValueClass(type, nullable)
                 handleObjectType(type, nullable)
             }
 
@@ -162,6 +163,20 @@ internal class SerializationIntrospectionContext(
         val ref = TypeRef.Ref(id, nullable)
         if (!nullable) typeRefCache[descriptor] = ref
         return ref
+    }
+
+    /**
+     * Handles inline value classes by delegating to the inner element's type.
+     *
+     * Inline value classes serialize as their inner value (e.g. `14.5` instead of
+     * `{"gramsPerDeciliter": 14.5}`), so the schema must reflect the inner type.
+     */
+    private fun handleInlineValueClass(
+        descriptor: SerialDescriptor,
+        nullable: Boolean,
+    ): TypeRef {
+        val innerRef = toRef(descriptor.getElementDescriptor(0))
+        return if (nullable && !innerRef.nullable) innerRef.withNullable(true) else innerRef
     }
 
     /**

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -80,8 +80,11 @@ internal class SerializationIntrospectionContext(
             }
 
             is StructureKind.CLASS, StructureKind.OBJECT -> {
-                if (type.isInline) return handleInlineValueClass(type, nullable)
-                handleObjectType(type, nullable)
+                if (type.isInline) {
+                    handleInlineValueClass(type, nullable)
+                } else {
+                    handleObjectType(type, nullable)
+                }
             }
 
             is StructureKind.MAP -> {
@@ -175,6 +178,7 @@ internal class SerializationIntrospectionContext(
         descriptor: SerialDescriptor,
         nullable: Boolean,
     ): TypeRef {
+        require(descriptor.elementsCount == 1) { "Inline value class descriptor must have exactly one element" }
         val innerRef = toRef(descriptor.getElementDescriptor(0))
         return if (nullable && !innerRef.nullable) innerRef.withNullable(true) else innerRef
     }

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGeneratorTest.kt
@@ -3,6 +3,7 @@ package kotlinx.schema.generator.json.serialization
 import io.kotest.assertions.json.shouldEqualJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
 import kotlin.test.Test
 
 class SerializationClassJsonSchemaGeneratorTest {
@@ -175,6 +176,17 @@ class SerializationClassJsonSchemaGeneratorTest {
                 "objectProperty": {
                   "$ref": "#/$defs/kotlinx.schema.generator.json.serialization.SerializationClassJsonSchemaGeneratorTest.TestObject",
                   "description": "A test object property"
+                },
+                "inlineValueClass": {
+                  "type": "number",
+                  "description": "A custom inline value class"
+                },
+                "inlineValueClassNullable": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "description": "A custom inline value class nullable"
                 }
               },
               "additionalProperties": false,

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
@@ -39,14 +39,10 @@ class SerializationIntrospectorTest {
         val color: Color,
     )
 
-    @JvmInline
-    @Serializable
-    value class Meters(val value: Double)
-
     @Serializable
     data class WithInlineValueClass(
-        val distance: Meters,
-        val optionalDistance: Meters?,
+        val distance: InlineValueClass,
+        val optionalDistance: InlineValueClass?,
     )
 
     @Serializable

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
@@ -16,6 +16,7 @@ import kotlinx.schema.generator.core.ir.TypeId
 import kotlinx.schema.generator.core.ir.TypeRef
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
+import kotlin.jvm.JvmInline
 import kotlin.test.Test
 import kotlinx.schema.generator.json.serialization.SerializationClassSchemaIntrospector as SerializationIntrospector
 
@@ -36,6 +37,16 @@ class SerializationIntrospectorTest {
     @Serializable
     data class WithEnum(
         val color: Color,
+    )
+
+    @JvmInline
+    @Serializable
+    value class Meters(val value: Double)
+
+    @Serializable
+    data class WithInlineValueClass(
+        val distance: Meters,
+        val optionalDistance: Meters?,
     )
 
     @Serializable
@@ -187,6 +198,35 @@ class SerializationIntrospectorTest {
 
         subtypeIds.forEach { id ->
             graph.nodes[TypeId(id)].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
+        }
+    }
+
+    @Test
+    fun `introspects inline value class as its inner primitive type`() {
+        val graph = introspector.introspect(WithInlineValueClass.serializer().descriptor)
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val objNode = graph.nodes[rootRef.id].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
+        val props = objNode.properties.associateBy { it.name }
+
+        // Non-nullable inline value class should resolve to an inline primitive
+        props.getValue("distance") shouldNotBeNull {
+            type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+                inline.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
+                    prim.kind shouldBe PrimitiveKind.DOUBLE
+                }
+                inline.nullable shouldBe false
+            }
+        }
+
+        // Nullable inline value class should resolve to a nullable inline primitive
+        props.getValue("optionalDistance") shouldNotBeNull {
+            type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+                inline.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
+                    prim.kind shouldBe PrimitiveKind.DOUBLE
+                }
+                inline.nullable shouldBe true
+            }
         }
     }
 

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/TestFixtures.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/TestFixtures.kt
@@ -6,6 +6,7 @@ import kotlinx.schema.generator.json.serialization.SerializationClassJsonSchemaG
 import kotlinx.schema.generator.json.serialization.SerializationClassJsonSchemaGeneratorTest.TestObject
 import kotlinx.serialization.SerialInfo
 import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
 
 @SerialInfo
 annotation class CustomDescription(
@@ -49,4 +50,14 @@ data class TestClass(
     val enumProperty: TestEnum = TestEnum.One,
     @property:CustomDescription("A test object property")
     val objectProperty: TestObject = TestObject,
+    @property:CustomDescription("A custom inline value class")
+    val inlineValueClass: InlineValueClass = InlineValueClass(10.0),
+    @property:CustomDescription("A custom inline value class nullable")
+    val inlineValueClassNullable: InlineValueClass? = null,
+)
+
+@JvmInline
+@Serializable
+value class InlineValueClass(
+    val value: Double,
 )


### PR DESCRIPTION
Inline value classes (e.g. `@JvmInline value class Meters(val value: Double)`) are serialized by kotlinx-serialization as their inner primitive value (just `1.5`), not as an object (`{"value": 1.5}`). However, the schema introspector was treating them as regular classes, generating an object schema with a property.

This caused a mismatch: the generated JSON schema told consumers (e.g. LLMs) to send
`{"distance": {"value": 1.5}}` when the serializer actually expects `{"distance": 1.5}`.

The fix checks `SerialDescriptor.isInline` before falling through to `handleObjectType` and delegates to the inner element's type reference instead, producing the correct primitive schema.