### PR TITLE
fix: Propagate inline value class descriptions to flattened primitive schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,4 @@ gradle-app.setting
 /test_*.*
 /debug_*.*
 /.junie/
-/.claude/
+**/.claude/

--- a/docs/serializable.md
+++ b/docs/serializable.md
@@ -218,6 +218,11 @@ This code prints:
 > and collections. A description annotation on a property whose type is another class will appear
 > in the schema alongside the `$ref` for that class.
 
+> [!TIP]
+> For inline value classes, the **class-level** description annotation propagates to the flattened
+> primitive property in the schema. If the property itself also has a description annotation,
+> the property-level one takes precedence. Annotations on the inner `value` property are not used.
+
 > [!IMPORTANT]
 > `SerialDescriptor` only carries annotations marked with
 > [`@SerialInfo`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-serial-info/).

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -174,8 +174,9 @@ internal class SerializationIntrospectionContext(
      * Inline value classes serialize as their inner value (e.g. `14.5` instead of
      * `{"gramsPerDeciliter": 14.5}`), so the schema must reflect the inner type.
      *
-     * If the inline class has a description (via annotations), it is propagated to the
-     * flattened primitive node so that it appears in the generated schema.
+     * If the inline class has a **class-level** description annotation, it is propagated to the
+     * flattened primitive node so that it appears in the generated schema. Annotations on the
+     * inner `value` property are not used.
      */
     private fun handleInlineValueClass(
         descriptor: SerialDescriptor,
@@ -184,12 +185,20 @@ internal class SerializationIntrospectionContext(
         require(descriptor.elementsCount == 1) { "Inline value class descriptor must have exactly one element" }
         val innerRef = toRef(descriptor.getElementDescriptor(0))
         val description = extractDescription(descriptor)
-        val effectiveRef = if (description != null && innerRef is TypeRef.Inline && innerRef.node is PrimitiveNode) {
-            val annotatedNode = (innerRef.node as PrimitiveNode).copy(description = description)
-            TypeRef.Inline(annotatedNode, innerRef.nullable)
-        } else {
-            innerRef
-        }
+        val effectiveRef =
+            if (innerRef is TypeRef.Inline && innerRef.node is PrimitiveNode) {
+                if (description != null) {
+                    TypeRef.Inline(
+                        (innerRef.node as PrimitiveNode).copy(description = description),
+                        innerRef.nullable,
+                    )
+                } else {
+                    innerRef
+                }
+            } else {
+                innerRef
+            }
+        if (!nullable) typeRefCache[descriptor] = effectiveRef
         return if (nullable && !effectiveRef.nullable) effectiveRef.withNullable(true) else effectiveRef
     }
 

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -173,6 +173,9 @@ internal class SerializationIntrospectionContext(
      *
      * Inline value classes serialize as their inner value (e.g. `14.5` instead of
      * `{"gramsPerDeciliter": 14.5}`), so the schema must reflect the inner type.
+     *
+     * If the inline class has a description (via annotations), it is propagated to the
+     * flattened primitive node so that it appears in the generated schema.
      */
     private fun handleInlineValueClass(
         descriptor: SerialDescriptor,
@@ -180,7 +183,14 @@ internal class SerializationIntrospectionContext(
     ): TypeRef {
         require(descriptor.elementsCount == 1) { "Inline value class descriptor must have exactly one element" }
         val innerRef = toRef(descriptor.getElementDescriptor(0))
-        return if (nullable && !innerRef.nullable) innerRef.withNullable(true) else innerRef
+        val description = extractDescription(descriptor)
+        val effectiveRef = if (description != null && innerRef is TypeRef.Inline && innerRef.node is PrimitiveNode) {
+            val annotatedNode = (innerRef.node as PrimitiveNode).copy(description = description)
+            TypeRef.Inline(annotatedNode, innerRef.nullable)
+        } else {
+            innerRef
+        }
+        return if (nullable && !effectiveRef.nullable) effectiveRef.withNullable(true) else effectiveRef
     }
 
     /**

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGeneratorTest.kt
@@ -3,7 +3,6 @@ package kotlinx.schema.generator.json.serialization
 import io.kotest.assertions.json.shouldEqualJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.jvm.JvmInline
 import kotlin.test.Test
 
 class SerializationClassJsonSchemaGeneratorTest {
@@ -59,6 +58,13 @@ class SerializationClassJsonSchemaGeneratorTest {
     data class WithDescribedInlineValueClass(
         val distance: DescribedInlineValueClass,
         val optionalDistance: DescribedInlineValueClass?,
+    )
+
+    @Serializable
+    @SerialName("WithPropertyOverridesInlineDescription")
+    data class WithPropertyOverridesInlineDescription(
+        @property:CustomDescription("Override description")
+        val distance: DescribedInlineValueClass,
     )
 
     val generator =
@@ -330,6 +336,31 @@ class SerializationClassJsonSchemaGeneratorTest {
               "required": [
                 "distance",
                 "optionalDistance"
+              ],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `property-level description overrides inline value class description in schema`() {
+        val schema = generator.generateSchemaString(WithPropertyOverridesInlineDescription.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "WithPropertyOverridesInlineDescription",
+              "type": "object",
+              "properties": {
+                "distance": {
+                  "type": "number",
+                  "description": "Override description"
+                }
+              },
+              "required": [
+                "distance"
               ],
               "additionalProperties": false
             }

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGeneratorTest.kt
@@ -55,6 +55,12 @@ class SerializationClassJsonSchemaGeneratorTest {
     @CustomDescription("A test data object")
     data object TestObject
 
+    @Serializable
+    data class WithDescribedInlineValueClass(
+        val distance: DescribedInlineValueClass,
+        val optionalDistance: DescribedInlineValueClass?,
+    )
+
     val generator =
         SerializationClassJsonSchemaGenerator(
             introspectorConfig =
@@ -293,6 +299,39 @@ class SerializationClassJsonSchemaGeneratorTest {
                   "additionalProperties": false
                 }
               }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `Should propagate inline value class description to flattened primitive in schema`() {
+        val schema = generator.generateSchemaString(WithDescribedInlineValueClass.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.generator.json.serialization.SerializationClassJsonSchemaGeneratorTest.WithDescribedInlineValueClass",
+              "type": "object",
+              "properties": {
+                "distance": {
+                  "type": "number",
+                  "description": "Distance in meters"
+                },
+                "optionalDistance": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "description": "Distance in meters"
+                }
+              },
+              "required": [
+                "distance",
+                "optionalDistance"
+              ],
+              "additionalProperties": false
             }
             """.trimIndent()
     }

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
@@ -46,6 +46,11 @@ class SerializationIntrospectorTest {
     )
 
     @Serializable
+    data class WithDescribedInlineValueClass(
+        val distance: DescribedInlineValueClass,
+    )
+
+    @Serializable
     sealed class Shape {
         @Serializable
         data class Circle(
@@ -222,6 +227,31 @@ class SerializationIntrospectorTest {
                     prim.kind shouldBe PrimitiveKind.DOUBLE
                 }
                 inline.nullable shouldBe true
+            }
+        }
+    }
+
+    @Test
+    fun `inline value class description propagates to flattened primitive`() {
+        val introspectorWithDescriptions = SerializationIntrospector(
+            config = SerializationIntrospector.Config(
+                descriptionExtractor = { annotations ->
+                    annotations.filterIsInstance<CustomDescription>().firstOrNull()?.value
+                },
+            ),
+        )
+        val graph = introspectorWithDescriptions.introspect(
+            WithDescribedInlineValueClass.serializer().descriptor,
+        )
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val objNode = graph.nodes[rootRef.id].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
+        val distanceProp = objNode.properties.first { it.name == "distance" }
+
+        distanceProp.type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+            inline.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
+                prim.kind shouldBe PrimitiveKind.DOUBLE
+                prim.description shouldBe "Distance in meters"
             }
         }
     }

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
@@ -16,7 +16,6 @@ import kotlinx.schema.generator.core.ir.TypeId
 import kotlinx.schema.generator.core.ir.TypeRef
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
-import kotlin.jvm.JvmInline
 import kotlin.test.Test
 import kotlinx.schema.generator.json.serialization.SerializationClassSchemaIntrospector as SerializationIntrospector
 
@@ -47,6 +46,12 @@ class SerializationIntrospectorTest {
 
     @Serializable
     data class WithDescribedInlineValueClass(
+        val distance: DescribedInlineValueClass,
+    )
+
+    @Serializable
+    data class WithPropertyOverridesInlineDescription(
+        @property:CustomDescription("Override description")
         val distance: DescribedInlineValueClass,
     )
 
@@ -233,16 +238,19 @@ class SerializationIntrospectorTest {
 
     @Test
     fun `inline value class description propagates to flattened primitive`() {
-        val introspectorWithDescriptions = SerializationIntrospector(
-            config = SerializationIntrospector.Config(
-                descriptionExtractor = { annotations ->
-                    annotations.filterIsInstance<CustomDescription>().firstOrNull()?.value
-                },
-            ),
-        )
-        val graph = introspectorWithDescriptions.introspect(
-            WithDescribedInlineValueClass.serializer().descriptor,
-        )
+        val introspectorWithDescriptions =
+            SerializationIntrospector(
+                config =
+                    SerializationIntrospector.Config(
+                        descriptionExtractor = { annotations ->
+                            annotations.filterIsInstance<CustomDescription>().firstOrNull()?.value
+                        },
+                    ),
+            )
+        val graph =
+            introspectorWithDescriptions.introspect(
+                WithDescribedInlineValueClass.serializer().descriptor,
+            )
 
         val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
         val objNode = graph.nodes[rootRef.id].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
@@ -251,6 +259,34 @@ class SerializationIntrospectorTest {
         distanceProp.type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
             inline.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
                 prim.kind shouldBe PrimitiveKind.DOUBLE
+                prim.description shouldBe "Distance in meters"
+            }
+        }
+    }
+
+    @Test
+    fun `property-level description overrides inline value class description in IR`() {
+        val introspectorWithDescriptions =
+            SerializationIntrospector(
+                config =
+                    SerializationIntrospector.Config(
+                        descriptionExtractor = { annotations ->
+                            annotations.filterIsInstance<CustomDescription>().firstOrNull()?.value
+                        },
+                    ),
+            )
+        val graph =
+            introspectorWithDescriptions.introspect(
+                WithPropertyOverridesInlineDescription.serializer().descriptor,
+            )
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val objNode = graph.nodes[rootRef.id].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
+        val distanceProp = objNode.properties.first { it.name == "distance" }
+
+        distanceProp.description shouldBe "Override description"
+        distanceProp.type.shouldBeInstanceOf<TypeRef.Inline> { inline ->
+            inline.node.shouldBeInstanceOf<PrimitiveNode> { prim ->
                 prim.description shouldBe "Distance in meters"
             }
         }

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/TestFixtures.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/TestFixtures.kt
@@ -61,3 +61,10 @@ data class TestClass(
 value class InlineValueClass(
     val value: Double,
 )
+
+@CustomDescription("Distance in meters")
+@JvmInline
+@Serializable
+value class DescribedInlineValueClass(
+    val value: Double,
+)


### PR DESCRIPTION
When an inline value class has a description annotation, the description was lost during flattening to a primitive type. This change preserves the description by copying it to the inner `PrimitiveNode`.

This is useful for communicating semantic information (e.g. canonical units like "Hemoglobin concentration in g/dL") through the schema when the type is flattened to a bare number.

 ## Additional changes                                                                                                         
                                                                                                                                
  - **Cache fix**: `handleInlineValueClass` now stores the resolved `TypeRef` in `typeRefCache`,                                
    matching the pattern of `handleListType`/`handleMapType`. Without this, every use of the same                               
    inline value class in a schema re-ran annotation extraction and allocated a fresh node.                                     
  - **Description precedence**: when a property carrying an inline value class also has its own                                 
    description annotation, the property-level annotation takes precedence over the class-level one.                            
    Both the IR state and the emitted JSON Schema are tested.                                                                   
  - **KDoc**: `handleInlineValueClass` now documents that only the **class-level** annotation is                                
    used; annotations on the inner `value` property are not propagated.                                                         
  - **Docs**: added a `TIP` to `docs/serializable.md` explaining inline value class description                                 
    behaviour and the property-level-wins precedence rule.
