### PR TITLE
feat: Support open polymorphism via SerializersModule (#297)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Quick Links:
 
 - **Compile-time (KSP)**: Zero runtime overhead, multiplatform, for your annotated classes
 - **Runtime (Reflection)**: JVM-only, for any class including third-party libraries
-- **Runtime (SerialDescriptor)**: Kotlin serializable classes
+- **Runtime (SerialDescriptor)**: Kotlin serializable classes, including open polymorphism via `SerializersModule`
 
 **LLM Integration:**
 
@@ -111,7 +111,7 @@ Quick Links:
 **Comprehensive Type Support:**
 
 - **Enums, collections, maps, nested objects, nullability, generics** (with star-projection)
-- **Sealed class hierarchies** with automatic `oneOf` generation and discriminator field
+- **Polymorphic hierarchies** — sealed classes and open polymorphism (via `SerializersModule`) with automatic `oneOf` generation and discriminator field
 - **Union types** for nullable parameters (`["string", "null"]`)
 - **Type constraints** (min/max, patterns, formats) via the JSON Schema DSL
 - **Default values** (compile-time: tracked but not extracted; runtime: fully extracted)

--- a/docs/serializable.md
+++ b/docs/serializable.md
@@ -14,6 +14,8 @@
   * [JsonSchemaConfig presets](#jsonschemaconfig-presets)
   * [JsonSchemaConfig reference](#jsonschemaconfig-reference)
 * [Polymorphic types](#polymorphic-types)
+  * [Sealed polymorphism](#sealed-polymorphism)
+  * [Open polymorphism](#open-polymorphism)
 * [See Also](#see-also)
 
 <!--- END -->
@@ -106,11 +108,11 @@ For custom behavior, construct the generator directly with explicit `introspecto
 
 `SerializationClassJsonSchemaGenerator` accepts three optional constructor parameters:
 
-| Parameter            | Type                                          | Default                    | Description                                               |
-|:---------------------|:----------------------------------------------|:---------------------------|:----------------------------------------------------------|
-| `json`               | `Json`                                        | `Json.Default`             | JSON configuration; controls discriminator name and mode. |
-| `introspectorConfig` | `SerializationClassSchemaIntrospector.Config` | `Config()`                 | Controls how descriptors are introspected.                |
-| `jsonSchemaConfig`   | `JsonSchemaConfig`                            | `JsonSchemaConfig.Default` | Controls schema output (nullability, required).           |
+| Parameter            | Type                                          | Default                    | Description                                     |
+|:---------------------|:----------------------------------------------|:---------------------------|:------------------------------------------------|
+| `json`               | `Json`                                        | `Json.Default`             | Controls JSON configuration.                    |
+| `introspectorConfig` | `SerializationClassSchemaIntrospector.Config` | `Config()`                 | Controls how descriptors are introspected.      |
+| `jsonSchemaConfig`   | `JsonSchemaConfig`                            | `JsonSchemaConfig.Default` | Controls schema output (nullability, required). |
 
 ### Introspector configuration
 
@@ -376,7 +378,12 @@ This code generates:
 
 ## Polymorphic types
 
-Sealed classes are supported. The generator reads the discriminator configuration from the `Json` instance you provide:
+Both sealed and open polymorphic hierarchies are supported. The generator reads the discriminator
+name from `Json.classDiscriminator` and produces `oneOf` schemas with `$defs` for each subtype.
+
+### Sealed polymorphism
+
+For sealed classes, the compiler embeds all subtypes in the `SerialDescriptor` — no `SerializersModule` needed:
 
 <!--- CLEAR -->
 <!--- INCLUDE
@@ -393,11 +400,11 @@ import kotlinx.serialization.json.Json
 @SerialName("com.example.Shape")
 sealed class Shape {
     @Serializable
-    @SerialName("com.example.Shape.Circle") 
+    @SerialName("com.example.Shape.Circle")
     data class Circle(val radius: Double) : Shape()
-    
+
     @Serializable
-    @SerialName("com.example.Shape.Rectangle") 
+    @SerialName("com.example.Shape.Rectangle")
     data class Rectangle(val width: Double, val height: Double) : Shape()
 }
 ```
@@ -419,9 +426,7 @@ println(schemaString)
 -->
 <!--- KNIT example-knit-serializable-05.kt -->
 
-The generated schema uses `oneOf` with a `$defs` section for each subtype. 
-Each subtype gets a required `type` property containing the subtype's serial name as a constant (from `@SerialName`), 
-enabling runtime dispatch.
+Each subtype gets a required discriminator property containing the subtype's serial name as a constant:
 
 ```json
 {
@@ -479,6 +484,72 @@ enabling runtime dispatch.
     }
 }
 ```
+
+### Open polymorphism
+
+For abstract classes and interfaces where subtypes aren't known at compile time, register them
+in a `SerializersModule` and pass it via the `Json` configuration. Only the registered subtypes
+appear in the generated schema:
+
+<!--- CLEAR -->
+<!--- INCLUDE
+import kotlinx.schema.generator.json.serialization.SerializationClassJsonSchemaGenerator
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+-->
+```kotlin
+@Serializable
+@SerialName("com.example.Flying")
+abstract class Flying {
+    abstract val name: String
+}
+
+@Serializable
+@SerialName("com.example.Bird")
+data class Bird(override val name: String, val wingspan: Double) : Flying()
+
+@Serializable
+@SerialName("com.example.Kite")
+data class Kite(override val name: String, val material: String) : Flying()
+```
+
+<!--- INCLUDE
+fun main() {
+-->
+```kotlin
+val module = SerializersModule {
+    polymorphic(Flying::class) {
+        subclass(Bird::class)
+        subclass(Kite::class)
+    }
+}
+
+val generator = SerializationClassJsonSchemaGenerator(
+    json = Json { serializersModule = module }
+)
+
+val schema = generator.generateSchemaString(
+    PolymorphicSerializer(Flying::class).descriptor
+)
+
+println(schema)
+```
+<!--- SUFFIX
+}
+-->
+<!--- KNIT example-knit-serializable-06.kt -->
+
+The output follows the same `oneOf` / `$defs` structure as sealed classes. Register only a subset
+of subtypes to produce a schema limited to those types.
+
+> [!NOTE]
+> Use `PolymorphicSerializer(Base::class).descriptor` as the entry point for open polymorphic
+> types — `Base.serializer()` is not available for non-sealed abstract classes.
 
 ## See Also
 

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerialDescriptorExtensions.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerialDescriptorExtensions.kt
@@ -1,0 +1,20 @@
+package kotlinx.schema.generator.json.serialization
+
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+
+private const val POLYMORPHIC_PREFIX = "kotlinx.serialization.Polymorphic<"
+private const val POLYMORPHIC_SUFFIX = ">"
+
+/**
+ * Returns the base type serial name, unwrapping the `kotlinx.serialization.Polymorphic<Name>`
+ * wrapper for open polymorphic descriptors.
+ *
+ * For all other descriptor kinds, returns [SerialDescriptor.serialName] unchanged.
+ */
+internal fun SerialDescriptor.unwrapSerialName(): String =
+    if (kind is PolymorphicKind.OPEN) {
+        serialName.removeSurrounding(POLYMORPHIC_PREFIX, POLYMORPHIC_SUFFIX)
+    } else {
+        serialName
+    }

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationClassJsonSchemaGenerator.kt
@@ -33,7 +33,7 @@ public class SerializationClassJsonSchemaGenerator(
                 json = json,
             ),
     ) {
-    override fun getRootName(target: SerialDescriptor): String = target.serialName
+    override fun getRootName(target: SerialDescriptor): String = target.unwrapSerialName()
 
     override fun targetType(): KClass<SerialDescriptor> = SerialDescriptor::class
 

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -15,11 +15,14 @@ import kotlinx.schema.generator.core.ir.Property
 import kotlinx.schema.generator.core.ir.SubtypeRef
 import kotlinx.schema.generator.core.ir.TypeId
 import kotlinx.schema.generator.core.ir.TypeRef
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModuleCollector
+import kotlin.reflect.KClass
 import kotlinx.serialization.descriptors.PrimitiveKind as SerialPrimitiveKind
 
 /**
@@ -282,13 +285,11 @@ internal class SerializationIntrospectionContext(
     }
 
     /**
-     * Handles polymorphic types (sealed classes) by creating a [PolymorphicNode].
+     * Handles polymorphic types (sealed and open) by creating a [PolymorphicNode].
      *
-     * For sealed classes, the descriptor structure is:
-     * - descriptor.kind is PolymorphicKind.SEALED
-     * - descriptor.elementDescriptors[0] is the discriminator descriptor (name "klass" or similar)
-     * - descriptor.elementDescriptors[1] is the "value" descriptor containing subtypes
-     * - The "value" descriptor's elementDescriptors are the actual subtype descriptors
+     * For sealed classes, subtypes are extracted from the descriptor structure.
+     * For open polymorphic types, subtypes are resolved from the
+     * [SerializersModule][kotlinx.serialization.modules.SerializersModule] registered in the [Json] instance.
      */
     private fun handlePolymorphicType(
         descriptor: SerialDescriptor,
@@ -299,7 +300,10 @@ internal class SerializationIntrospectionContext(
         withCycleDetection(descriptor, id) {
             // Extract subtypes from the nested structure
             val subtypeDescriptors = extractPolymorphicSubtypes(descriptor)
-            val subtypes = subtypeDescriptors.map { SubtypeRef(TypeId(it.serialName)) }
+            val subtypes =
+                subtypeDescriptors
+                    .sortedBy { it.serialName }
+                    .map { SubtypeRef(TypeId(it.serialName)) }
 
             // Get discriminator configuration from Json
             val discriminatorName = json.configuration.classDiscriminator
@@ -331,21 +335,27 @@ internal class SerializationIntrospectionContext(
     }
 
     /**
-     * Extracts subtype descriptors from a sealed polymorphic descriptor.
+     * Extracts subtype descriptors from a polymorphic descriptor.
      *
-     * The structure of a sealed class descriptor is:
+     * For sealed classes (`PolymorphicKind.SEALED`), subtypes are embedded in the descriptor:
      * ```
      * SerialDescriptor (PolymorphicKind.SEALED)
      *   ├─ element[0] → "klass" discriminator descriptor
      *   └─ element[1] → "value" descriptor containing subtypes
      *        └─ elements → [subtype1, subtype2, ...]
      * ```
+     *
+     * For open polymorphism (`PolymorphicKind.OPEN`), subtypes are resolved from the
+     * [SerializersModule][kotlinx.serialization.modules.SerializersModule] registered in the [Json] instance.
      */
-    private fun extractPolymorphicSubtypes(descriptor: SerialDescriptor): List<SerialDescriptor> {
-        require(descriptor.kind is PolymorphicKind.SEALED) {
-            "Expected sealed polymorphic descriptor, got ${descriptor.kind}"
+    private fun extractPolymorphicSubtypes(descriptor: SerialDescriptor): List<SerialDescriptor> =
+        when (descriptor.kind) {
+            is PolymorphicKind.SEALED -> extractSealedSubtypes(descriptor)
+            is PolymorphicKind.OPEN -> extractOpenSubtypes(descriptor)
+            else -> error("Expected polymorphic descriptor, got ${descriptor.kind}")
         }
 
+    private fun extractSealedSubtypes(descriptor: SerialDescriptor): List<SerialDescriptor> {
         require(descriptor.elementsCount >= 2 && descriptor.getElementName(1) == "value") {
             "Unexpected sealed descriptor structure: expected 'value' element at index 1, " +
                 "but found '${descriptor.getElementName(1)}'"
@@ -353,6 +363,62 @@ internal class SerializationIntrospectionContext(
 
         val valueDescriptor = descriptor.getElementDescriptor(1)
         return (0 until valueDescriptor.elementsCount).map { valueDescriptor.getElementDescriptor(it) }
+    }
+
+    /**
+     * Extracts subtype descriptors for open polymorphic types by querying the
+     * [SerializersModule][kotlinx.serialization.modules.SerializersModule].
+     *
+     * Iterates all polymorphic registrations in the module and collects descriptors
+     * whose base class matches the given [descriptor]'s serial name.
+     *
+     * @throws IllegalStateException if no subtypes are registered for this base type
+     */
+    private fun extractOpenSubtypes(descriptor: SerialDescriptor): List<SerialDescriptor> {
+        val baseSerialName = descriptor.serialName
+        val subtypeDescriptors = mutableListOf<SerialDescriptor>()
+        val baseClassSerialNames = mutableMapOf<KClass<*>, String>()
+
+        json.serializersModule.dumpTo(
+            object : SerializersModuleCollector {
+                override fun <T : Any> contextual(
+                    kClass: KClass<T>,
+                    provider: (typeArgumentsSerializers: List<KSerializer<*>>) -> KSerializer<*>,
+                ) = Unit
+
+                override fun <Base : Any, Sub : Base> polymorphic(
+                    baseClass: KClass<Base>,
+                    actualClass: KClass<Sub>,
+                    actualSerializer: KSerializer<Sub>,
+                ) {
+                    val cachedName = baseClassSerialNames.getOrPut(baseClass) {
+                        kotlinx.serialization.PolymorphicSerializer(baseClass).descriptor.serialName
+                    }
+                    if (cachedName == baseSerialName) {
+                        subtypeDescriptors.add(actualSerializer.descriptor)
+                    }
+                }
+
+                override fun <Base : Any> polymorphicDefaultSerializer(
+                    baseClass: KClass<Base>,
+                    defaultSerializerProvider: (value: Base) -> kotlinx.serialization.SerializationStrategy<Base>?,
+                ) = Unit
+
+                override fun <Base : Any> polymorphicDefaultDeserializer(
+                    baseClass: KClass<Base>,
+                    defaultDeserializerProvider: (
+                        className: String?,
+                    ) -> kotlinx.serialization.DeserializationStrategy<Base>?,
+                ) = Unit
+            },
+        )
+
+        check(subtypeDescriptors.isNotEmpty()) {
+            "No subtypes registered in SerializersModule for open polymorphic type '$baseSerialName'. " +
+                "Register subtypes via polymorphic(Base::class) { subclass(Sub::class) } in the module."
+        }
+
+        return subtypeDescriptors
     }
 
     /**
@@ -380,8 +446,17 @@ internal class SerializationIntrospectionContext(
 
     /**
      * Creates a [TypeId] from a [SerialDescriptor] using its serialName.
+     *
+     * For open polymorphic descriptors, unwraps the `kotlinx.serialization.Polymorphic<Name>`
+     * wrapper to extract the inner type name.
      */
-    private fun descriptorId(descriptor: SerialDescriptor): TypeId = TypeId(descriptor.serialName.removeSuffix("?"))
+    private fun descriptorId(descriptor: SerialDescriptor): TypeId =
+        TypeId(descriptor.unwrapSerialName().removeSuffix("?"))
+
+    private companion object {
+        /** Serial names that represent "any value" — mapped to [AnyNode] (empty schema `{}`). */
+        val ANY_SERIAL_NAMES = setOf("kotlin.Any", "java.lang.Object")
+    }
 
     /**
      * Extracts description from a list of type annotations.
@@ -405,9 +480,4 @@ internal class SerializationIntrospectionContext(
             is TypeRef.Inline -> copy(nullable = nullable)
             is TypeRef.Ref -> copy(nullable = nullable)
         }
-
-    private companion object {
-        /** Serial names that represent "any value" — mapped to [AnyNode] (empty schema `{}`). */
-        val ANY_SERIAL_NAMES = setOf("kotlin.Any", "java.lang.Object")
-    }
 }

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/OpenPolymorphismSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/OpenPolymorphismSchemaGeneratorTest.kt
@@ -1,0 +1,157 @@
+@file:Suppress("RUNTIME_ANNOTATION_NOT_SUPPORTED")
+
+package kotlinx.schema.generator.json.serialization
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
+import kotlinx.schema.generator.json.SerialDescription
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import kotlin.test.Test
+
+@Suppress("ANNOTATION_TARGETS_IN_JS")
+class OpenPolymorphismSchemaGeneratorTest {
+    @Suppress("AbstractClassCanBeInterface")
+    @Serializable
+    @SerialName("Flying")
+    @SerialDescription("Something that flies")
+    abstract class Flying {
+        abstract val name: String
+    }
+
+    @Serializable
+    @SerialName("Bird")
+    @SerialDescription("A flying bird")
+    data class Bird(
+        @property:SerialDescription("Bird name") override val name: String,
+        @property:SerialDescription("Wingspan in meters") val wingspan: Double,
+    ) : Flying()
+
+    @Serializable
+    @SerialName("Kite")
+    @SerialDescription("A man-made kite")
+    data class Kite(
+        @property:SerialDescription("Kite name") override val name: String,
+        @property:SerialDescription("Material used") val material: String,
+    ) : Flying()
+
+    @Test
+    fun `subtypes from SerializersModule`() {
+        val module =
+            SerializersModule {
+                polymorphic(Flying::class) {
+                    subclass(Bird::class)
+                    subclass(Kite::class)
+                }
+            }
+
+        val generator =
+            SerializationClassJsonSchemaGenerator(
+                json = Json { serializersModule = module },
+            )
+
+        val schema = generator.generateSchemaString(PolymorphicSerializer(Flying::class).descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Flying",
+              "type": "object",
+              "additionalProperties": false,
+              "oneOf": [
+                { "$ref": "#/$defs/Bird" },
+                { "$ref": "#/$defs/Kite" }
+              ],
+              "$defs": {
+                "Bird": {
+                  "type": "object",
+                  "description": "A flying bird",
+                  "properties": {
+                    "type": { "type": "string", "const": "Bird" },
+                    "name": { "type": "string", "description": "Bird name" },
+                    "wingspan": { "type": "number", "description": "Wingspan in meters" }
+                  },
+                  "required": ["type", "name", "wingspan"],
+                  "additionalProperties": false
+                },
+                "Kite": {
+                  "type": "object",
+                  "description": "A man-made kite",
+                  "properties": {
+                    "type": { "type": "string", "const": "Kite" },
+                    "name": { "type": "string", "description": "Kite name" },
+                    "material": { "type": "string", "description": "Material used" }
+                  },
+                  "required": ["type", "name", "material"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `partial module includes only registered subtypes`() {
+        val module =
+            SerializersModule {
+                polymorphic(Flying::class) {
+                    subclass(Kite::class)
+                }
+            }
+
+        val generator =
+            SerializationClassJsonSchemaGenerator(
+                json = Json { serializersModule = module },
+            )
+
+        val schema = generator.generateSchemaString(PolymorphicSerializer(Flying::class).descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Flying",
+              "type": "object",
+              "additionalProperties": false,
+              "oneOf": [
+                { "$ref": "#/$defs/Kite" }
+              ],
+              "$defs": {
+                "Kite": {
+                  "type": "object",
+                  "description": "A man-made kite",
+                  "properties": {
+                    "type": { "type": "string", "const": "Kite" },
+                    "name": { "type": "string", "description": "Kite name" },
+                    "material": { "type": "string", "description": "Material used" }
+                  },
+                  "required": ["type", "name", "material"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `empty module fails with descriptive message`() {
+        val generator = SerializationClassJsonSchemaGenerator()
+
+        val exception =
+            shouldThrow<IllegalStateException> {
+                generator.generateSchemaString(PolymorphicSerializer(Flying::class).descriptor)
+            }
+
+        exception.message shouldContain "No subtypes registered in SerializersModule"
+        exception.message shouldContain "Flying"
+    }
+}

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SealedPolymorphismSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SealedPolymorphismSchemaGeneratorTest.kt
@@ -1,0 +1,149 @@
+@file:Suppress("RUNTIME_ANNOTATION_NOT_SUPPORTED")
+
+package kotlinx.schema.generator.json.serialization
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.schema.generator.json.SerialDescription
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import kotlin.test.Test
+
+class SealedPolymorphismSchemaGeneratorTest {
+    @Serializable
+    @SerialName("Shape")
+    @SerialDescription("A geometric shape")
+    sealed class Shape {
+        @Serializable
+        @SerialName("Circle")
+        @SerialDescription("A circle")
+        data class Circle(
+            @property:SerialDescription("Circle radius") val radius: Double,
+        ) : Shape()
+
+        @Serializable
+        @SerialName("Rect")
+        @SerialDescription("A rectangle")
+        data class Rect(
+            @property:SerialDescription("Rectangle width") val w: Double,
+        ) : Shape()
+    }
+
+    @Test
+    fun `custom classDiscriminator from Json config`() {
+        val module =
+            SerializersModule {
+                polymorphic(Shape::class) {
+                    subclass(Shape.Circle::class)
+                    subclass(Shape.Rect::class)
+                }
+            }
+
+        val generator =
+            SerializationClassJsonSchemaGenerator(
+                json =
+                    Json {
+                        serializersModule = module
+                        classDiscriminator = "kind"
+                    },
+            )
+
+        val schema = generator.generateSchemaString(Shape.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Shape",
+              "description": "A geometric shape",
+              "type": "object",
+              "additionalProperties": false,
+              "oneOf": [
+                { "$ref": "#/$defs/Circle" },
+                { "$ref": "#/$defs/Rect" }
+              ],
+              "$defs": {
+                "Circle": {
+                  "type": "object",
+                  "description": "A circle",
+                  "properties": {
+                    "kind": { "type": "string", "const": "Circle" },
+                    "radius": { "type": "number", "description": "Circle radius" }
+                  },
+                  "required": ["kind", "radius"],
+                  "additionalProperties": false
+                },
+                "Rect": {
+                  "type": "object",
+                  "description": "A rectangle",
+                  "properties": {
+                    "kind": { "type": "string", "const": "Rect" },
+                    "w": { "type": "number", "description": "Rectangle width" }
+                  },
+                  "required": ["kind", "w"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `SerializersModule does not filter sealed subtypes - all come from SerialDescriptor`() {
+        val partialModule =
+            SerializersModule {
+                polymorphic(Shape::class) {
+                    subclass(Shape.Rect::class)
+                }
+            }
+
+        val generator =
+            SerializationClassJsonSchemaGenerator(
+                json = Json { serializersModule = partialModule },
+            )
+
+        val schema = generator.generateSchemaString(Shape.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Shape",
+              "description": "A geometric shape",
+              "type": "object",
+              "additionalProperties": false,
+              "oneOf": [
+                { "$ref": "#/$defs/Circle" },
+                { "$ref": "#/$defs/Rect" }
+              ],
+              "$defs": {
+                "Circle": {
+                  "type": "object",
+                  "description": "A circle",
+                  "properties": {
+                    "type": { "type": "string", "const": "Circle" },
+                    "radius": { "type": "number", "description": "Circle radius" }
+                  },
+                  "required": ["type", "radius"],
+                  "additionalProperties": false
+                },
+                "Rect": {
+                  "type": "object",
+                  "description": "A rectangle",
+                  "properties": {
+                    "type": { "type": "string", "const": "Rect" },
+                    "w": { "type": "number", "description": "Rectangle width" }
+                  },
+                  "required": ["type", "w"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}


### PR DESCRIPTION
## Description


- Open polymorphic types (abstract classes, interfaces) now generate JSON Schema when subtypes are registered in a `SerializersModule` passed via the `Json` parameter
- Sealed polymorphism continues to work as before — subtypes come from `SerialDescriptor`                                       
- Subtypes from `SerializersModule` are sorted alphabetically for deterministic output                                          
- Fails fast with a descriptive error when no subtypes are registered for an open type                                          
- `$id` in generated schema uses the unwrapped base type name (e.g. `Flying`) instead of `kotlinx.serialization.Polymorphic<Flying>` 

**Related Issues:** Close #297

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [ ] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements
