### PR TITLE
feat: add @SchemaIgnore and @SerialSchemaIgnore annotations to exclude subtypes from schema generation (#277)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   * [Nested objects](#nested-objects)
   * [Generic types](#generic-types)
   * [Sealed class polymorphism](#sealed-class-polymorphism)
+    * [Excluding subtypes with @SchemaIgnore](#excluding-subtypes-with-@schemaignore)
 * [Using @Schema and @Description annotations](#using-@schema-and-@description-annotations)
   * [@Schema annotation](#@schema-annotation)
   * [@Description annotation](#@description-annotation)
@@ -669,6 +670,44 @@ println(schema.encodeToString(Json { prettyPrint = true }))
 - **Discriminator property**: A `type` field with a `const` value is automatically added to each subtype for runtime dispatch
 - **Property inheritance**: Base class properties are included in each subtype
 - **Type safety**: Each subtype gets its own schema definition
+
+#### Excluding subtypes with @SchemaIgnore
+
+Use `@SchemaIgnore` to exclude specific sealed subtypes from the generated schema.
+The class remains fully functional at runtime — only schema generation is affected:
+
+```kotlin
+@Schema
+sealed class Event {
+    data class Click(val x: Int, val y: Int) : Event()
+
+    @SchemaIgnore
+    data class Internal(val trace: String) : Event()
+}
+```
+
+The `Internal` subtype will not appear in the `oneOf` composition or `$defs`.
+
+For serialization-based generation, use `@SerialSchemaIgnore` (which carries `@SerialInfo`):
+
+```kotlin
+@Serializable
+sealed class Event {
+    @Serializable
+    data class Click(val x: Int, val y: Int) : Event()
+
+    @Serializable
+    @SerialSchemaIgnore
+    data class Internal(val trace: String) : Event()
+}
+```
+
+Jackson's `@JsonIgnoreType` is also recognized automatically. Custom ignore annotations can be
+registered via `kotlinx-schema.properties`:
+
+```properties
+introspector.annotations.ignore.names=SchemaIgnore,SerialSchemaIgnore,JsonIgnoreType,MyCustomIgnore
+```
 
 ## Using @Schema and @Description annotations
 

--- a/docs/serializable.md
+++ b/docs/serializable.md
@@ -15,6 +15,7 @@
   * [JsonSchemaConfig reference](#jsonschemaconfig-reference)
 * [Polymorphic types](#polymorphic-types)
   * [Sealed polymorphism](#sealed-polymorphism)
+  * [Excluding subtypes with @SerialSchemaIgnore](#excluding-subtypes-with-@serialschemaignore)
   * [Open polymorphism](#open-polymorphism)
 * [See Also](#see-also)
 
@@ -484,6 +485,34 @@ Each subtype gets a required discriminator property containing the subtype's ser
     }
 }
 ```
+
+### Excluding subtypes with @SerialSchemaIgnore
+
+Sealed hierarchies sometimes contain subtypes that shouldn't appear in the schema — internal sentinels,
+testing stubs, or deprecated variants. Annotate them with `@SerialSchemaIgnore` to exclude them from
+the generated `oneOf` composition and `$defs`:
+
+```kotlin
+@Serializable
+@SerialName("com.example.Event")
+sealed class Event {
+    @Serializable
+    @SerialName("com.example.Event.Click")
+    data class Click(val x: Int, val y: Int) : Event()
+
+    @Serializable
+    @SerialName("com.example.Event.Internal")
+    @SerialSchemaIgnore
+    data class Internal(val trace: String) : Event()
+}
+```
+
+The `Internal` subtype compiles and serializes normally — only schema generation skips it.
+
+> [!NOTE]
+> `@SerialSchemaIgnore` carries `@SerialInfo` so it's preserved in `SerialDescriptor`.
+> The plain `@SchemaIgnore` annotation (from `kotlinx-schema-annotations`) works with KSP and
+> reflection generators but is not visible through `SerialDescriptor`.
 
 ### Open polymorphism
 

--- a/kotlinx-schema-annotations/Module.md
+++ b/kotlinx-schema-annotations/Module.md
@@ -8,6 +8,8 @@ Core annotations for marking classes and functions for schema generation.
 
 - [@Schema][kotlinx.schema.Schema] - marks declarations for schema generation. Recognized by compile-time KSP generator.
 - [@Description][kotlinx.schema.Description] - adds human-readable descriptions to schemas
+- [@SchemaIgnore][kotlinx.schema.SchemaIgnore] - excludes a class (e.g., sealed subtype) from schema generation
+
 ## Example
 
 ```kotlin

--- a/kotlinx-schema-annotations/api/kotlinx-schema-annotations.api
+++ b/kotlinx-schema-annotations/api/kotlinx-schema-annotations.api
@@ -7,3 +7,6 @@ public abstract interface annotation class kotlinx/schema/Schema : java/lang/ann
 	public abstract fun withSchemaObject ()Z
 }
 
+public abstract interface annotation class kotlinx/schema/SchemaIgnore : java/lang/annotation/Annotation {
+}
+

--- a/kotlinx-schema-annotations/api/kotlinx-schema-annotations.klib.api
+++ b/kotlinx-schema-annotations/api/kotlinx-schema-annotations.klib.api
@@ -21,3 +21,7 @@ open annotation class kotlinx.schema/Schema : kotlin/Annotation { // kotlinx.sch
     final val withSchemaObject // kotlinx.schema/Schema.withSchemaObject|{}withSchemaObject[0]
         final fun <get-withSchemaObject>(): kotlin/Boolean // kotlinx.schema/Schema.withSchemaObject.<get-withSchemaObject>|<get-withSchemaObject>(){}[0]
 }
+
+open annotation class kotlinx.schema/SchemaIgnore : kotlin/Annotation { // kotlinx.schema/SchemaIgnore|null[0]
+    constructor <init>() // kotlinx.schema/SchemaIgnore.<init>|<init>(){}[0]
+}

--- a/kotlinx-schema-annotations/src/commonMain/kotlin/kotlinx/schema/SchemaIgnore.kt
+++ b/kotlinx-schema-annotations/src/commonMain/kotlin/kotlinx/schema/SchemaIgnore.kt
@@ -1,0 +1,34 @@
+package kotlinx.schema
+
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+
+/**
+ * Excludes the annotated class from schema generation.
+ *
+ * When applied to a sealed subtype, the subtype is omitted from the parent's
+ * polymorphic `oneOf` schema. The class remains fully functional at runtime —
+ * only schema generation is affected.
+ *
+ * All three generators (KSP, reflection, serialization) recognize this annotation.
+ * For serialization-based generation where annotations must carry
+ * [@SerialInfo][kotlinx.serialization.SerialInfo], use
+ * `@SerialSchemaIgnore` from the `kotlinx-schema-generator-json` module instead.
+ *
+ * Example:
+ * ```kotlin
+ * @Schema
+ * sealed class Event {
+ *     data class Click(val x: Int, val y: Int) : Event()
+ *
+ *     @SchemaIgnore
+ *     data class Internal(val trace: String) : Event()
+ * }
+ * ```
+ *
+ * @see kotlinx.schema.Schema
+ */
+@Target(CLASS)
+@Retention(RUNTIME)
+@MustBeDocumented
+public annotation class SchemaIgnore

--- a/kotlinx-schema-generator-core/api/kotlinx-schema-generator-core.api
+++ b/kotlinx-schema-generator-core/api/kotlinx-schema-generator-core.api
@@ -89,6 +89,7 @@ public final class kotlinx/schema/generator/core/ir/EnumNode : kotlinx/schema/ge
 public final class kotlinx/schema/generator/core/ir/Introspections {
 	public static final field INSTANCE Lkotlinx/schema/generator/core/ir/Introspections;
 	public static final fun getDescriptionFromAnnotation (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
+	public static final fun isIgnoreAnnotation (Ljava/lang/String;)Z
 }
 
 public final class kotlinx/schema/generator/core/ir/ListNode : kotlinx/schema/generator/core/ir/TypeNode {

--- a/kotlinx-schema-generator-core/api/kotlinx-schema-generator-core.klib.api
+++ b/kotlinx-schema-generator-core/api/kotlinx-schema-generator-core.klib.api
@@ -351,4 +351,5 @@ final class kotlinx.schema.generator.core.ir/TypeId { // kotlinx.schema.generato
 
 final object kotlinx.schema.generator.core.ir/Introspections { // kotlinx.schema.generator.core.ir/Introspections|null[0]
     final fun getDescriptionFromAnnotation(kotlin/String, kotlin.collections/List<kotlin/Pair<kotlin/String, kotlin/Any?>>): kotlin/String? // kotlinx.schema.generator.core.ir/Introspections.getDescriptionFromAnnotation|getDescriptionFromAnnotation(kotlin.String;kotlin.collections.List<kotlin.Pair<kotlin.String,kotlin.Any?>>){}[0]
+    final fun isIgnoreAnnotation(kotlin/String): kotlin/Boolean // kotlinx.schema.generator.core.ir/Introspections.isIgnoreAnnotation|isIgnoreAnnotation(kotlin.String){}[0]
 }

--- a/kotlinx-schema-generator-core/build.gradle.kts
+++ b/kotlinx-schema-generator-core/build.gradle.kts
@@ -10,6 +10,14 @@ dokka {
 }
 
 kotlin {
+    compilerOptions {
+        optIn.set(
+            listOf(
+                "kotlinx.schema.generator.core.InternalSchemaGeneratorApi",
+            ),
+        )
+    }
+
     sourceSets {
         commonMain {
             dependencies {

--- a/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/Config.kt
+++ b/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/Config.kt
@@ -54,4 +54,17 @@ internal expect object Config {
      * - For `@JsonPropertyDescription(description = "User email")`, the "description" parameter contains "User email"
      */
     val descriptionValueAttributes: Set<String>
+
+    /**
+     * Set of lowercase annotation simple names recognized as ignore markers.
+     *
+     * Classes annotated with any of these annotations are excluded from schema generation
+     * (e.g., sealed subtypes omitted from polymorphic `oneOf` schemas).
+     *
+     * Loaded lazily from the `introspector.annotations.ignore.names` property in
+     * `kotlinx-schema.properties`. If loading fails, falls back to built-in defaults.
+     *
+     * Default value: SchemaIgnore, SerialSchemaIgnore, JsonIgnoreType
+     */
+    val ignoreAnnotationNames: Set<String>
 }

--- a/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/ir/Introspections.kt
+++ b/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/ir/Introspections.kt
@@ -1,9 +1,11 @@
 package kotlinx.schema.generator.core.ir
 
 import kotlinx.schema.generator.core.Config
+import kotlinx.schema.generator.core.InternalSchemaGeneratorApi
 import kotlinx.schema.generator.core.ir.Introspections.descriptionAnnotationNames
 import kotlinx.schema.generator.core.ir.Introspections.descriptionValueAttributes
 import kotlinx.schema.generator.core.ir.Introspections.getDescriptionFromAnnotation
+import kotlinx.schema.generator.core.ir.Introspections.isIgnoreAnnotation
 import kotlin.jvm.JvmStatic
 
 /**
@@ -36,8 +38,10 @@ import kotlin.jvm.JvmStatic
  * Your project's properties file will take precedence over the library's default configuration.
  *
  * @see getDescriptionFromAnnotation
+ * @see isIgnoreAnnotation
  * @see Config
  */
+@InternalSchemaGeneratorApi
 public object Introspections {
     /**
      * Set of lowercase annotation simple names recognized as description providers.
@@ -45,6 +49,13 @@ public object Introspections {
      * @see Config.descriptionAnnotationNames
      */
     private val descriptionAnnotationNames: Set<String> = Config.descriptionAnnotationNames
+
+    /**
+     * Set of lowercase annotation simple names recognized as ignore markers.
+     *
+     * @see Config.ignoreAnnotationNames
+     */
+    private val ignoreAnnotationNames: Set<String> = Config.ignoreAnnotationNames
 
     /**
      * Set of lowercase annotation parameter names that may contain description text.
@@ -120,6 +131,18 @@ public object Introspections {
         } else {
             null
         }
+
+    /**
+     * Checks whether the given annotation simple name is recognized as an ignore marker.
+     *
+     * Matching is case-insensitive by simple name only (not fully qualified name),
+     * following the same convention as [getDescriptionFromAnnotation].
+     *
+     * @param annotationName The simple name of the annotation to check (e.g., "SchemaIgnore", "JsonIgnoreType")
+     * @return `true` if the annotation is recognized as an ignore marker
+     */
+    @JvmStatic
+    public fun isIgnoreAnnotation(annotationName: String): Boolean = annotationName.lowercase() in ignoreAnnotationNames
 }
 
 /**

--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/core/Config.jvm.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/core/Config.jvm.kt
@@ -9,6 +9,7 @@ import kotlin.use
 private const val CONFIG_FILE_NAME = "kotlinx-schema.properties"
 private const val DESCRIPTION_NAMES_KEY = "introspector.annotations.description.names"
 private const val DESCRIPTION_ATTRIBUTES_KEY = "introspector.annotations.description.attributes"
+private const val IGNORE_NAMES_KEY = "introspector.annotations.ignore.names"
 
 /**
  * Default fallback values if configuration loading fails
@@ -29,6 +30,16 @@ private val DEFAULT_VALUE_ATTRIBUTES =
     setOf(
         "value",
         "description",
+    )
+
+/**
+ * Default fallback values if configuration loading fails
+ */
+private val DEFAULT_IGNORE_NAMES =
+    setOf(
+        "schemaignore",
+        "serialschemaignore",
+        "jsonignoretype",
     )
 
 internal actual object Config {
@@ -70,6 +81,12 @@ internal actual object Config {
         loadConfiguration { properties ->
             parseListProperty(properties, DESCRIPTION_ATTRIBUTES_KEY)
         } ?: DEFAULT_VALUE_ATTRIBUTES
+    }
+
+    actual val ignoreAnnotationNames: Set<String> by lazy {
+        loadConfiguration { properties ->
+            parseListProperty(properties, IGNORE_NAMES_KEY)
+        } ?: DEFAULT_IGNORE_NAMES
     }
 
     private fun <T> loadConfiguration(extractor: (Properties) -> T): T? =

--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectionContext.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectionContext.kt
@@ -1,6 +1,5 @@
 package kotlinx.schema.generator.reflect
 
-import kotlinx.schema.generator.core.InternalSchemaGeneratorApi
 import kotlinx.schema.generator.core.ir.AnyNode
 import kotlinx.schema.generator.core.ir.BaseIntrospectionContext
 import kotlinx.schema.generator.core.ir.Discriminator
@@ -26,7 +25,6 @@ import kotlin.reflect.full.createType
  * Only supports [KClass] classifiers for introspection, generics are not supported.
  */
 @Suppress("TooManyFunctions")
-@OptIn(InternalSchemaGeneratorApi::class)
 internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>() {
     /**
      * This is a shared instance, so different schema generation runs would reuse the same class metadata cache.
@@ -196,9 +194,10 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
         val id = createTypeId(klass)
 
         withCycleDetection(type, id) {
-            val polymorphicNode = createPolymorphicNode(klass)
+            val filteredSubclasses = klass.filteredSealedSubclasses()
+            val polymorphicNode = createPolymorphicNode(klass, filteredSubclasses)
 
-            klass.sealedSubclasses.forEach { subclass ->
+            filteredSubclasses.forEach { subclass ->
                 toRef(subclass.createType())
             }
 
@@ -348,20 +347,24 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
     }
 
     /**
-     * Creates a [PolymorphicNode] from a [KClass]
+     * Creates a [PolymorphicNode] from a [KClass] using the given [sealedSubclasses]
+     * (already filtered to exclude `@SchemaIgnore`-annotated subtypes).
      */
-    private fun createPolymorphicNode(klass: KClass<*>): PolymorphicNode {
+    private fun createPolymorphicNode(
+        klass: KClass<*>,
+        sealedSubclasses: List<KClass<*>>,
+    ): PolymorphicNode {
         val baseName = klass.simpleName ?: "UnknownSealed"
 
         val subtypes =
-            klass.sealedSubclasses.map { subclass ->
+            sealedSubclasses.map { subclass ->
                 SubtypeRef(createTypeId(subclass))
             }
 
         // Build discriminator mapping: discriminator value -> TypeId
         // Key must equal the TypeId value so it matches the `const` value the transformer emits
         val discriminatorMapping =
-            klass.sealedSubclasses.associate { subclass ->
+            sealedSubclasses.associate { subclass ->
                 val id = createTypeId(subclass)
                 id.value to id
             }
@@ -378,6 +381,12 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
             description = extractDescription(klass.annotations),
         )
     }
+
+    /**
+     * Returns sealed subclasses excluding those annotated with a recognized ignore annotation.
+     */
+    private fun KClass<*>.filteredSealedSubclasses(): List<KClass<*>> =
+        sealedSubclasses.filter { !isSchemaIgnored(it.annotations) }
 
     //endregion
 

--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionUtils.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionUtils.kt
@@ -43,6 +43,18 @@ internal fun findPropertyByName(
         .firstOrNull { it.name == propertyName }
 
 /**
+ * Checks whether the given list of annotations contains a recognized ignore marker
+ * (e.g., `@SchemaIgnore`, `@SerialSchemaIgnore`, `@JsonIgnoreType`).
+ *
+ * @see [Introspections.isIgnoreAnnotation]
+ */
+internal fun isSchemaIgnored(annotations: List<Annotation>): Boolean =
+    annotations.any { annotation ->
+        val name = annotation.annotationClass.simpleName ?: return@any false
+        Introspections.isIgnoreAnnotation(name)
+    }
+
+/**
  * Extracts description from annotations.
  *
  * @see [Introspections.getDescriptionFromAnnotation]

--- a/kotlinx-schema-generator-core/src/jvmMain/resources/kotlinx-schema.properties
+++ b/kotlinx-schema-generator-core/src/jvmMain/resources/kotlinx-schema.properties
@@ -24,3 +24,13 @@ introspector.annotations.description.names=Description,SerialDescription,LLMDesc
 ## - value: Standard for annotations like @Description("text")
 ## - description: Common for verbose annotations like @JsonPropertyDescription(description = "text")
 introspector.annotations.description.attributes=value,description
+
+## Annotation simple names to recognize as ignore markers
+## Classes annotated with any of these are excluded from schema generation
+## (e.g. sealed subtypes omitted from polymorphic oneOf schemas)
+##
+## Default annotations supported:
+## - SchemaIgnore (kotlinx-schema)
+## - SerialSchemaIgnore (kotlinx-schema, serialization-aware)
+## - JsonIgnoreType (Jackson)
+introspector.annotations.ignore.names=SchemaIgnore,SerialSchemaIgnore,JsonIgnoreType

--- a/kotlinx-schema-generator-core/src/jvmTest/kotlin/kotlinx/schema/generator/core/ir/IntrospectionsTest.kt
+++ b/kotlinx-schema-generator-core/src/jvmTest/kotlin/kotlinx/schema/generator/core/ir/IntrospectionsTest.kt
@@ -78,4 +78,42 @@ class IntrospectionsTest {
         ) shouldBe null
     }
     //endregion
+
+    //region Ignore annotation recognition
+
+    @ParameterizedTest
+    @CsvSource(
+        "SchemaIgnore",
+        "SerialSchemaIgnore",
+        "JsonIgnoreType",
+    )
+    fun `recognizes ignore annotations by simple name`(name: String) {
+        Introspections.isIgnoreAnnotation(name) shouldBe true
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "schemaignore",
+        "SCHEMAIGNORE",
+        "SchemaIgnore",
+        "jsonignoretype",
+        "JSONIGNORETYPE",
+    )
+    fun `ignore annotation matching is case-insensitive`(name: String) {
+        Introspections.isIgnoreAnnotation(name) shouldBe true
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "Ignore",
+        "JsonIgnore",
+        "Transient",
+        "Description",
+        "UnknownAnnotation",
+    )
+    fun `does not match unrecognized annotation names as ignore`(name: String) {
+        Introspections.isIgnoreAnnotation(name) shouldBe false
+    }
+
+    //endregion
 }

--- a/kotlinx-schema-generator-core/src/jvmTest/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectorTest.kt
+++ b/kotlinx-schema-generator-core/src/jvmTest/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectorTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.schema.Description
+import kotlinx.schema.SchemaIgnore
 import kotlinx.schema.generator.core.ir.AnyNode
 import kotlinx.schema.generator.core.ir.EnumNode
 import kotlinx.schema.generator.core.ir.ListNode
@@ -58,6 +59,15 @@ class ReflectionIntrospectorTest {
         }
 
         data class Bicycle(val gears: Int) : Vehicle()
+    }
+
+    @Suppress("unused")
+    sealed class Event {
+        data class Click(val x: Int, val y: Int) : Event()
+        data class PageView(val url: String) : Event()
+
+        @SchemaIgnore
+        data class Internal(val trace: String) : Event()
     }
 
     data class WithAny(
@@ -218,6 +228,25 @@ class ReflectionIntrospectorTest {
             ].shouldNotBeNull()
                 .shouldBeInstanceOf<ObjectNode>()
         rectangleNode.description shouldBe "Rectangle shape"
+    }
+
+    @Test
+    fun `sealed class excludes @SchemaIgnore subtypes from polymorphic node`() {
+        val graph = introspector.introspect(Event::class)
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val polyNode = graph.nodes[rootRef.id].shouldNotBeNull().shouldBeInstanceOf<PolymorphicNode>()
+
+        val subtypeIds = polyNode.subtypes.map { it.id.value }.toSet()
+        subtypeIds.shouldContainExactlyInAnyOrder(
+            setOf(
+                "kotlinx.schema.generator.reflect.ReflectionIntrospectorTest.Event.Click",
+                "kotlinx.schema.generator.reflect.ReflectionIntrospectorTest.Event.PageView",
+            ),
+        )
+
+        // Internal should not appear in nodes
+        graph.nodes.keys.none { it.value.contains("Internal") } shouldBe true
     }
 
     @Test

--- a/kotlinx-schema-generator-core/src/nativeMain/kotlin/kotlinx/schema/generator/core/Config.native.kt
+++ b/kotlinx-schema-generator-core/src/nativeMain/kotlin/kotlinx/schema/generator/core/Config.native.kt
@@ -5,4 +5,6 @@ internal actual object Config {
         get() = setOf("Description")
     actual val descriptionValueAttributes: Set<String>
         get() = setOf("value", "description")
+    actual val ignoreAnnotationNames: Set<String>
+        get() = setOf("schemaignore")
 }

--- a/kotlinx-schema-generator-core/src/webMain/kotlin/kotlinx/schema/generator/core/Config.web.kt
+++ b/kotlinx-schema-generator-core/src/webMain/kotlin/kotlinx/schema/generator/core/Config.web.kt
@@ -5,4 +5,6 @@ internal actual object Config {
         get() = setOf("Description")
     actual val descriptionValueAttributes: Set<String>
         get() = setOf("value", "description")
+    actual val ignoreAnnotationNames: Set<String>
+        get() = setOf("schemaignore")
 }

--- a/kotlinx-schema-generator-json/Module.md
+++ b/kotlinx-schema-generator-json/Module.md
@@ -58,6 +58,7 @@ val schema = generator.generateSchema(User.serializer().descriptor)
 **Serialization Generators (Multiplatform):**
 - Works on all kotlinx-serialization targets (JVM, Native, JS, Wasm)
 - Consistent with kotlinx-serialization behavior
+- [`@SerialSchemaIgnore`][kotlinx.schema.generator.json.SerialSchemaIgnore] to exclude sealed subtypes from generated schemas
 
 ## Limitations
 

--- a/kotlinx-schema-generator-json/api/kotlinx-schema-generator-json.api
+++ b/kotlinx-schema-generator-json/api/kotlinx-schema-generator-json.api
@@ -100,6 +100,13 @@ public final synthetic class kotlinx/schema/generator/json/SerialDescription$Imp
 	public final synthetic fun value ()Ljava/lang/String;
 }
 
+public abstract interface annotation class kotlinx/schema/generator/json/SerialSchemaIgnore : java/lang/annotation/Annotation {
+}
+
+public final synthetic class kotlinx/schema/generator/json/SerialSchemaIgnore$Impl : kotlinx/schema/generator/json/SerialSchemaIgnore {
+	public fun <init> ()V
+}
+
 public final class kotlinx/schema/generator/json/TypeGraphToFunctionCallingSchemaTransformer : kotlinx/schema/generator/core/ir/AbstractTypeGraphTransformer {
 	public fun <init> ()V
 	public fun <init> (Lkotlinx/schema/generator/json/FunctionCallingSchemaConfig;)V

--- a/kotlinx-schema-generator-json/api/kotlinx-schema-generator-json.klib.api
+++ b/kotlinx-schema-generator-json/api/kotlinx-schema-generator-json.klib.api
@@ -13,6 +13,10 @@ open annotation class kotlinx.schema.generator.json/SerialDescription : kotlin/A
         final fun <get-value>(): kotlin/String // kotlinx.schema.generator.json/SerialDescription.value.<get-value>|<get-value>(){}[0]
 }
 
+open annotation class kotlinx.schema.generator.json/SerialSchemaIgnore : kotlin/Annotation { // kotlinx.schema.generator.json/SerialSchemaIgnore|null[0]
+    constructor <init>() // kotlinx.schema.generator.json/SerialSchemaIgnore.<init>|<init>(){}[0]
+}
+
 abstract interface <#A: kotlin/Any> kotlinx.schema.generator.json/JsonSchemaGenerator : kotlinx.schema.generator.core/SchemaGenerator<#A, kotlinx.serialization.json/JsonObject> { // kotlinx.schema.generator.json/JsonSchemaGenerator|null[0]
     abstract fun generateSchema(#A): kotlinx.serialization.json/JsonObject // kotlinx.schema.generator.json/JsonSchemaGenerator.generateSchema|generateSchema(1:0){}[0]
     open fun encodeToString(kotlinx.serialization.json/JsonObject): kotlin/String // kotlinx.schema.generator.json/JsonSchemaGenerator.encodeToString|encodeToString(kotlinx.serialization.json.JsonObject){}[0]

--- a/kotlinx-schema-generator-json/build.gradle.kts
+++ b/kotlinx-schema-generator-json/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
         optIn.set(
             listOf(
                 "kotlinx.serialization.ExperimentalSerializationApi",
+                "kotlinx.schema.generator.core.InternalSchemaGeneratorApi",
             ),
         )
     }

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/SerialSchemaIgnore.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/SerialSchemaIgnore.kt
@@ -1,0 +1,37 @@
+package kotlinx.schema.generator.json
+
+import kotlinx.serialization.SerialInfo
+
+/**
+ * Excludes the annotated [@Serializable][kotlinx.serialization.Serializable] class from schema generation.
+ *
+ * Unlike [@SchemaIgnore][kotlinx.schema.SchemaIgnore], this annotation carries [@SerialInfo] so it is
+ * preserved in [SerialDescriptor][kotlinx.serialization.descriptors.SerialDescriptor] and is automatically
+ * recognized by the serialization-based schema generator.
+ *
+ * When applied to a sealed subtype, the subtype is omitted from the parent's
+ * polymorphic `oneOf` schema. The class remains fully functional at runtime —
+ * only schema generation is affected.
+ *
+ * Example:
+ * ```kotlin
+ * @Serializable
+ * sealed class Event {
+ *     @Serializable
+ *     data class Click(val x: Int, val y: Int) : Event()
+ *
+ *     @Serializable
+ *     @SerialSchemaIgnore
+ *     data class Internal(val trace: String) : Event()
+ * }
+ * ```
+ *
+ * @see kotlinx.schema.SchemaIgnore
+ * @see SerialDescription
+ */
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+@SerialInfo
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+public annotation class SerialSchemaIgnore

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -1,6 +1,5 @@
 package kotlinx.schema.generator.json.serialization
 
-import kotlinx.schema.generator.core.InternalSchemaGeneratorApi
 import kotlinx.schema.generator.core.ir.AnyNode
 import kotlinx.schema.generator.core.ir.BaseIntrospectionContext
 import kotlinx.schema.generator.core.ir.Discriminator
@@ -15,6 +14,7 @@ import kotlinx.schema.generator.core.ir.Property
 import kotlinx.schema.generator.core.ir.SubtypeRef
 import kotlinx.schema.generator.core.ir.TypeId
 import kotlinx.schema.generator.core.ir.TypeRef
+import kotlinx.schema.generator.json.SerialSchemaIgnore
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -34,7 +34,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind as SerialPrimitiveKind
  * @property json The [Json] configuration used to extract discriminator settings for polymorphic types
  */
 @Suppress("TooManyFunctions")
-@OptIn(InternalSchemaGeneratorApi::class)
 internal class SerializationIntrospectionContext(
     private val json: Json,
     private val config: SerializationClassSchemaIntrospector.Config,
@@ -298,8 +297,10 @@ internal class SerializationIntrospectionContext(
         val id = descriptorId(descriptor)
 
         withCycleDetection(descriptor, id) {
-            // Extract subtypes from the nested structure
-            val subtypeDescriptors = extractPolymorphicSubtypes(descriptor)
+            // Extract subtypes from the nested structure, excluding @SerialSchemaIgnore-annotated ones
+            val subtypeDescriptors =
+                extractPolymorphicSubtypes(descriptor)
+                    .filter { subtype -> !subtype.isSchemaIgnored() }
             val subtypes =
                 subtypeDescriptors
                     .sortedBy { it.serialName }
@@ -391,9 +392,12 @@ internal class SerializationIntrospectionContext(
                     actualClass: KClass<Sub>,
                     actualSerializer: KSerializer<Sub>,
                 ) {
-                    val cachedName = baseClassSerialNames.getOrPut(baseClass) {
-                        kotlinx.serialization.PolymorphicSerializer(baseClass).descriptor.serialName
-                    }
+                    val cachedName =
+                        baseClassSerialNames.getOrPut(baseClass) {
+                            kotlinx.serialization
+                                .PolymorphicSerializer(baseClass)
+                                .descriptor.serialName
+                        }
                     if (cachedName == baseSerialName) {
                         subtypeDescriptors.add(actualSerializer.descriptor)
                     }
@@ -457,6 +461,15 @@ internal class SerializationIntrospectionContext(
         /** Serial names that represent "any value" — mapped to [AnyNode] (empty schema `{}`). */
         val ANY_SERIAL_NAMES = setOf("kotlin.Any", "java.lang.Object")
     }
+
+    /**
+     * Checks whether the descriptor's class-level annotations include a recognized ignore marker.
+     *
+     * Note: Only recognizes [SerialSchemaIgnore] directly. Custom ignore annotations
+     * registered via `kotlinx-schema.properties` are not checked here because
+     * `Annotation::class.simpleName` is unreliable in Kotlin common code.
+     */
+    private fun SerialDescriptor.isSchemaIgnored(): Boolean = annotations.any { it is SerialSchemaIgnore }
 
     /**
      * Extracts description from a list of type annotations.

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SealedPolymorphismSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SealedPolymorphismSchemaGeneratorTest.kt
@@ -4,6 +4,7 @@ package kotlinx.schema.generator.json.serialization
 
 import io.kotest.assertions.json.shouldEqualJson
 import kotlinx.schema.generator.json.SerialDescription
+import kotlinx.schema.generator.json.SerialSchemaIgnore
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -146,4 +147,81 @@ class SealedPolymorphismSchemaGeneratorTest {
             }
             """.trimIndent()
     }
+
+    //region @SerialSchemaIgnore
+
+    @Serializable
+    @SerialName("Event")
+    @SerialDescription("An application event")
+    sealed class Event {
+        @Serializable
+        @SerialName("Click")
+        @SerialDescription("User clicked")
+        data class Click(
+            val x: Int,
+            val y: Int,
+        ) : Event()
+
+        @Serializable
+        @SerialName("PageView")
+        @SerialDescription("Page was viewed")
+        data class PageView(
+            val url: String,
+        ) : Event()
+
+        @Serializable
+        @SerialName("Internal")
+        @SerialSchemaIgnore
+        data class Internal(
+            val trace: String,
+        ) : Event()
+    }
+
+    @Test
+    fun `sealed class excludes SerialSchemaIgnore subtypes from oneOf schema`() {
+        val generator = SerializationClassJsonSchemaGenerator(json = Json)
+
+        val schema = generator.generateSchemaString(Event.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Event",
+              "description": "An application event",
+              "type": "object",
+              "additionalProperties": false,
+              "oneOf": [
+                { "$ref": "#/$defs/Click" },
+                { "$ref": "#/$defs/PageView" }
+              ],
+              "$defs": {
+                "Click": {
+                  "type": "object",
+                  "description": "User clicked",
+                  "properties": {
+                    "type": { "type": "string", "const": "Click" },
+                    "x": { "type": "integer" },
+                    "y": { "type": "integer" }
+                  },
+                  "required": ["type", "x", "y"],
+                  "additionalProperties": false
+                },
+                "PageView": {
+                  "type": "object",
+                  "description": "Page was viewed",
+                  "properties": {
+                    "type": { "type": "string", "const": "PageView" },
+                    "url": { "type": "string" }
+                  },
+                  "required": ["type", "url"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+
+    //endregion
 }

--- a/kotlinx-schema-ksp/build.gradle.kts
+++ b/kotlinx-schema-ksp/build.gradle.kts
@@ -10,6 +10,14 @@ dokka {
 }
 
 kotlin {
+    compilerOptions {
+        optIn.set(
+            listOf(
+                "kotlinx.schema.generator.core.InternalSchemaGeneratorApi",
+            ),
+        )
+    }
+
     dependencies {
         implementation(project(":kotlinx-schema-generator-json"))
         implementation(libs.ksp.api)

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/SchemaExtensionProcessor.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/SchemaExtensionProcessor.kt
@@ -12,6 +12,7 @@ import kotlinx.schema.ksp.functions.CompanionFunctionStrategy
 import kotlinx.schema.ksp.functions.InstanceFunctionStrategy
 import kotlinx.schema.ksp.functions.ObjectFunctionStrategy
 import kotlinx.schema.ksp.functions.TopLevelFunctionStrategy
+import kotlinx.schema.ksp.ir.isSchemaIgnored
 import kotlinx.schema.ksp.strategy.CodeGenerationContext
 import kotlinx.schema.ksp.type.ClassSchemaStrategy
 
@@ -186,6 +187,15 @@ internal class SchemaExtensionProcessor(
         classDeclarations.forEach { classDeclaration ->
             if (!classDeclaration.validate()) {
                 unprocessable.add(classDeclaration)
+                return@forEach
+            }
+
+            if (classDeclaration.isSchemaIgnored()) {
+                logger.error(
+                    "@Schema and @SchemaIgnore are contradictory on " +
+                        "${classDeclaration.qualifiedName?.asString()}. " +
+                        "Remove one of the annotations.",
+                )
                 return@forEach
             }
 

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspIntrospectionContext.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspIntrospectionContext.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Nullability
-import kotlinx.schema.generator.core.InternalSchemaGeneratorApi
+
 import kotlinx.schema.generator.core.ir.AnyNode
 import kotlinx.schema.generator.core.ir.BaseIntrospectionContext
 import kotlinx.schema.generator.core.ir.ObjectNode
@@ -29,7 +29,6 @@ import kotlinx.schema.generator.core.ir.TypeRef
  * 4. Enum classes -> EnumNode via [handleEnum]
  * 5. Regular objects/classes -> ObjectNode via [handleObjectOrClass]
  */
-@OptIn(InternalSchemaGeneratorApi::class)
 internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
     /**
      * Converts a KSType to a TypeRef using the standard resolution strategy.
@@ -115,8 +114,10 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
         val id = decl.typeId()
 
         withCycleDetection(type, id) {
-            // Find all sealed subclasses
-            val sealedSubclasses = decl.getSealedSubclasses().toList()
+            // Find all sealed subclasses, excluding those annotated with @SchemaIgnore
+            val sealedSubclasses = decl.getSealedSubclasses()
+                .filter { !it.isSchemaIgnored() }
+                .toList()
 
             // Create SubtypeRef for each sealed subclass using their typeId()
             val subtypes =

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/ignore.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/ignore.kt
@@ -1,0 +1,24 @@
+package kotlinx.schema.ksp.ir
+
+import com.google.devtools.ksp.symbol.KSAnnotated
+import kotlinx.schema.generator.core.ir.Introspections
+
+/**
+ * Checks whether the symbol is annotated with a recognized ignore annotation
+ * (e.g., `@SchemaIgnore`, `@SerialSchemaIgnore`, `@JsonIgnoreType`).
+ *
+ * Recognition is delegated to [Introspections.isIgnoreAnnotation], which performs
+ * case-insensitive matching by simple name against a configurable set loaded
+ * from `kotlinx-schema.properties`.
+ *
+ * @return `true` if any annotation on this symbol is recognized as an ignore marker
+ */
+internal fun KSAnnotated.isSchemaIgnored(): Boolean =
+    annotations.any { annotation ->
+        val name =
+            annotation.annotationType
+                .resolve()
+                .declaration.simpleName
+                .asString()
+        Introspections.isIgnoreAnnotation(name)
+    }

--- a/ksp-integration-tests/src/main/kotlin/kotlinx/schema/integration/type/Event.kt
+++ b/ksp-integration-tests/src/main/kotlin/kotlinx/schema/integration/type/Event.kt
@@ -1,0 +1,43 @@
+package kotlinx.schema.integration.type
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType
+import kotlinx.schema.Description
+import kotlinx.schema.Schema
+import kotlinx.schema.SchemaIgnore
+
+/**
+ * Test model for @SchemaIgnore on sealed subtypes.
+ */
+@Description("An application event")
+@Schema
+sealed class Event {
+    abstract val timestamp: Long
+
+    @Description("User clicked on an element")
+    data class Click(
+        override val timestamp: Long,
+        @Description("X coordinate")
+        val x: Int,
+        @Description("Y coordinate")
+        val y: Int,
+    ) : Event()
+
+    @Description("Page was viewed")
+    data class PageView(
+        override val timestamp: Long,
+        @Description("Page URL")
+        val url: String,
+    ) : Event()
+
+    @SchemaIgnore
+    data class Internal(
+        override val timestamp: Long,
+        val trace: String,
+    ) : Event()
+
+    @JsonIgnoreType
+    data class Jackson(
+        override val timestamp: Long,
+        val json: String,
+    ) : Event()
+}

--- a/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/type/EventSchemaTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/type/EventSchemaTest.kt
@@ -1,0 +1,88 @@
+package kotlinx.schema.integration.type
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlin.test.Test
+
+/**
+ * Tests for @SchemaIgnore on sealed subtypes — ignored subtypes must not appear
+ * in the polymorphic oneOf schema or $defs.
+ */
+class EventSchemaTest {
+    @Test
+    fun `sealed class excludes @SchemaIgnore and @JsonIgnoreType subtypes from oneOf schema`() {
+        val schema = Event::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.integration.type.Event",
+              "description": "An application event",
+              "type": "object",
+              "additionalProperties": false,
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/kotlinx.schema.integration.type.Event.Click"
+                },
+                {
+                  "$ref": "#/$defs/kotlinx.schema.integration.type.Event.PageView"
+                }
+              ],
+              "$defs": {
+                "kotlinx.schema.integration.type.Event.Click": {
+                  "type": "object",
+                  "description": "User clicked on an element",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "kotlinx.schema.integration.type.Event.Click"
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    },
+                    "x": {
+                      "type": "integer",
+                      "description": "X coordinate"
+                    },
+                    "y": {
+                      "type": "integer",
+                      "description": "Y coordinate"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "timestamp",
+                    "x",
+                    "y"
+                  ],
+                  "additionalProperties": false
+                },
+                "kotlinx.schema.integration.type.Event.PageView": {
+                  "type": "object",
+                  "description": "Page was viewed",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "kotlinx.schema.integration.type.Event.PageView"
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "Page URL"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "timestamp",
+                    "url"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}


### PR DESCRIPTION
## Description

- Add `@SchemaIgnore` (annotations module, RUNTIME) and `@SerialSchemaIgnore` (generator-json module, `@SerialInfo` + RUNTIME) to exclude sealed subtypes from generated oneOf schemas
- Generic configurable ignore filter in `Introspections.isIgnoreAnnotation()` — recognizes `SchemaIgnore`, `SerialSchemaIgnore`, and Jackson's `@JsonIgnoreType` by default, extensible via _kotlinx-schema.properties_
 - All three generators (KSP, reflection, serialization) filter ignored subtypes at their sealed-subclass discovery point
 - KSP processor fails fast with a compile error on contradictory `@Schema` + `@SchemaIgnore`
 - Introspections annotated with `@InternalSchemaGeneratorApi`; module-level optIn in build files keeps internal callers clean


**Related Issues:** Closes #277 

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements

