### PR TITLE
fix: handle recursive types in schema generation and route subtypes through cycle-safe path

### DIFF
--- a/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/ir/BaseIntrospectionContext.kt
+++ b/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/ir/BaseIntrospectionContext.kt
@@ -24,11 +24,11 @@ public abstract class BaseIntrospectionContext<TType : Any> {
     private val _nodes: MutableMap<TypeId, TypeNode> = linkedMapOf()
 
     /**
-     * Exposes discovered nodes as read-only copy for building TypeGraph.
+     * Exposes discovered nodes as an unmodifiable view for building TypeGraph.
      * Provides a consistent API across all introspector implementations (Reflection, KSP, Serialization).
      */
     public val nodes: Map<TypeId, TypeNode>
-        get() = _nodes.toMap()
+        get(): Map<TypeId, TypeNode> = _nodes
 
     /**
      * Set of types currently being visited (for cycle detection).

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonSchemaTransformer.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonSchemaTransformer.kt
@@ -571,7 +571,7 @@ public class TypeGraphToJsonSchemaTransformer
             graph: TypeGraph,
             definitions: MutableMap<String, PropertyDefinition>,
         ): PropertyDefinition {
-            // Convert each subtype and add to $defs, collect $ref for oneOf
+            // Convert each subtype via ensureNodeInDefinitions, then inject discriminator
             val subtypeRefs =
                 node.subtypes.map { subtypeRef ->
                     val typeName = subtypeRef.id.value
@@ -580,43 +580,29 @@ public class TypeGraphToJsonSchemaTransformer
                             "Subtype '$typeName' not found in type graph"
                         }
 
-                    val subtypeDefinition =
-                        when (val definition = convertNode(subtypeNode, nullable = false, graph, definitions)) {
-                            is ObjectPropertyDefinition -> {
-                                // Append discriminator property to the definition if enabled
-                                if (config.includePolymorphicDiscriminator) {
-                                    val discriminatorProperty =
-                                        StringPropertyDefinition(
-                                            constValue = JsonPrimitive(typeName),
-                                        )
+                    // Register subtype through the shared cycle-safe path
+                    ensureNodeInDefinitions(subtypeRef.id, subtypeNode, graph, definitions)
 
-                                    definition.copy(
-                                        properties =
-                                            mapOf(node.discriminator.name to discriminatorProperty) +
-                                                definition.properties.orEmpty(),
-                                        required = listOf(node.discriminator.name) + definition.required.orEmpty(),
-                                    )
-                                } else {
-                                    definition
-                                }
-                            }
+                    // Inject discriminator property into the registered definition if not already present
+                    val registered = definitions[typeName]
+                    if (
+                        registered is ObjectPropertyDefinition &&
+                        config.includePolymorphicDiscriminator &&
+                        node.discriminator.name !in registered.properties.orEmpty()
+                    ) {
+                        val discriminatorProperty =
+                            StringPropertyDefinition(
+                                constValue = JsonPrimitive(typeName),
+                            )
 
-                            // Nested sealed hierarchy: intermediate sealed subtype is itself polymorphic.
-                            // No discriminator injection — the leaf subtypes carry the const.
-                            is OneOfPropertyDefinition -> {
-                                definition
-                            }
-
-                            else -> {
-                                error(
-                                    "All subtypes of a polymorphic type must be objects or sealed hierarchies. " +
-                                        "Found subtype '$typeName' with type '${definition::class.simpleName}'.",
-                                )
-                            }
-                        }
-
-                    // Add to definitions map for $defs section
-                    definitions[typeName] = subtypeDefinition
+                        definitions[typeName] =
+                            registered.copy(
+                                properties =
+                                    mapOf(node.discriminator.name to discriminatorProperty) +
+                                        registered.properties.orEmpty(),
+                                required = listOf(node.discriminator.name) + registered.required.orEmpty(),
+                            )
+                    }
 
                     // Return a reference to this definition
                     ReferencePropertyDefinition(ref = $$"#/$defs/$$typeName")

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonSchemaTransformerTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/TypeGraphToJsonSchemaTransformerTest.kt
@@ -1,0 +1,182 @@
+package kotlinx.schema.generator.json
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.assertions.throwables.shouldThrow
+import kotlinx.schema.generator.core.ir.Discriminator
+import kotlinx.schema.generator.core.ir.ObjectNode
+import kotlinx.schema.generator.core.ir.PolymorphicNode
+import kotlinx.schema.generator.core.ir.PrimitiveKind
+import kotlinx.schema.generator.core.ir.PrimitiveNode
+import kotlinx.schema.generator.core.ir.Property
+import kotlinx.schema.generator.core.ir.SubtypeRef
+import kotlinx.schema.generator.core.ir.TypeGraph
+import kotlinx.schema.generator.core.ir.TypeId
+import kotlinx.schema.generator.core.ir.TypeRef
+import kotlinx.schema.json.encodeToString
+import kotlin.test.Test
+
+class TypeGraphToJsonSchemaTransformerTest {
+    private val transformer = TypeGraphToJsonSchemaTransformer(config = JsonSchemaConfig.Default)
+
+    @Test
+    fun `failed node conversion does not leave placeholder in definitions`() {
+        // A polymorphic type where one subtype references a TypeId not in the graph.
+        // convertNode for the object will fail when it tries to resolve the dangling ref.
+        val baseId = TypeId("Base")
+        val goodId = TypeId("Good")
+        val badId = TypeId("Bad")
+        val danglingId = TypeId("Dangling")
+
+        val goodNode = ObjectNode(
+            name = "Good",
+            properties = listOf(Property(name = "x", type = TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING)))),
+            required = setOf("x"),
+        )
+        // Bad references a type that doesn't exist in the graph
+        val badNode = ObjectNode(
+            name = "Bad",
+            properties = listOf(Property(name = "missing", type = TypeRef.Ref(danglingId))),
+            required = setOf("missing"),
+        )
+        val polyNode = PolymorphicNode(
+            baseName = "Base",
+            subtypes = listOf(SubtypeRef(goodId), SubtypeRef(badId)),
+            discriminator = Discriminator(name = "type"),
+        )
+
+        val rootNode = ObjectNode(
+            name = "Root",
+            properties = listOf(Property(name = "base", type = TypeRef.Ref(baseId))),
+            required = setOf("base"),
+        )
+        val rootId = TypeId("Root")
+
+        val graph = TypeGraph(
+            root = TypeRef.Ref(rootId),
+            nodes = mapOf(
+                rootId to rootNode,
+                baseId to polyNode,
+                goodId to goodNode,
+                badId to badNode,
+                // danglingId intentionally missing
+            ),
+        )
+
+        val error = shouldThrow<IllegalStateException> {
+            transformer.transform(graph, "Root")
+        }
+
+        // The error should mention the dangling reference
+        error.message.toString() shouldContainAny listOf("Dangling", "not found")
+    }
+
+    @Test
+    fun `subtype used both in polymorphic hierarchy and as property gets discriminator exactly once`() {
+        // Shape sealed hierarchy: Circle, Square
+        // Container has both a `shape: Shape` (polymorphic) and `primaryCircle: Circle` (direct ref)
+        // This exercises the path where Circle is registered via ensureNodeInDefinitions from
+        // the direct ref, then convertPolymorphic also encounters it.
+        val shapeId = TypeId("Shape")
+        val circleId = TypeId("Circle")
+        val squareId = TypeId("Square")
+
+        val circleNode = ObjectNode(
+            name = "Circle",
+            properties = listOf(Property(name = "radius", type = TypeRef.Inline(PrimitiveNode(PrimitiveKind.DOUBLE)))),
+            required = setOf("radius"),
+        )
+        val squareNode = ObjectNode(
+            name = "Square",
+            properties = listOf(Property(name = "side", type = TypeRef.Inline(PrimitiveNode(PrimitiveKind.DOUBLE)))),
+            required = setOf("side"),
+        )
+        val shapeNode = PolymorphicNode(
+            baseName = "Shape",
+            subtypes = listOf(SubtypeRef(circleId), SubtypeRef(squareId)),
+            discriminator = Discriminator(name = "type"),
+        )
+
+        // Container references Circle directly AND Shape (which includes Circle)
+        val containerId = TypeId("Container")
+        val containerNode = ObjectNode(
+            name = "Container",
+            properties = listOf(
+                Property(name = "primaryCircle", type = TypeRef.Ref(circleId)),
+                Property(name = "shape", type = TypeRef.Ref(shapeId)),
+            ),
+            required = setOf("primaryCircle", "shape"),
+        )
+
+        val graph = TypeGraph(
+            root = TypeRef.Ref(containerId),
+            nodes = mapOf(
+                containerId to containerNode,
+                shapeId to shapeNode,
+                circleId to circleNode,
+                squareId to squareNode,
+            ),
+        )
+
+        val schema = transformer.transform(graph, "Container")
+        val schemaJson = schema.encodeToString(json)
+
+        // Circle should have discriminator "type" exactly once in required
+        schemaJson shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Container",
+              "type": "object",
+              "properties": {
+                "primaryCircle": {
+                  "$ref": "#/$defs/Circle"
+                },
+                "shape": {
+                  "$ref": "#/$defs/Shape"
+                }
+              },
+              "required": ["primaryCircle", "shape"],
+              "additionalProperties": false,
+              "$defs": {
+                "Circle": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "Circle"
+                    },
+                    "radius": { "type": "number" }
+                  },
+                  "required": ["type", "radius"],
+                  "additionalProperties": false
+                },
+                "Shape": {
+                  "oneOf": [
+                    { "$ref": "#/$defs/Circle" },
+                    { "$ref": "#/$defs/Square" }
+                  ]
+                },
+                "Square": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "Square"
+                    },
+                    "side": { "type": "number" }
+                  },
+                  "required": ["type", "side"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}
+
+private infix fun String.shouldContainAny(candidates: List<String>) {
+    require(candidates.any { this.contains(it) }) {
+        "Expected string to contain any of $candidates, but was: $this"
+    }
+}

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/RecursiveTypeSchemaTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/RecursiveTypeSchemaTest.kt
@@ -1,0 +1,154 @@
+package kotlinx.schema.generator.json.serialization
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+
+class RecursiveTypeSchemaTest {
+    //region Test models
+
+    @Serializable
+    @SerialName("Node")
+    private sealed class Node {
+        abstract val id: String
+
+        @Serializable
+        @SerialName("Leaf")
+        data class Leaf(
+            override val id: String,
+            val value: String,
+        ) : Node()
+
+        @Serializable
+        @SerialName("Branch")
+        data class Branch(
+            override val id: String,
+            val left: Node?,
+            val right: Node,
+        ) : Node()
+    }
+
+    @Serializable
+    @SerialName("Tree")
+    private data class Tree(
+        val root: Node,
+    )
+
+    @Serializable
+    @SerialName("LinkedNode")
+    private data class LinkedNode(
+        val value: String,
+        val next: LinkedNode?,
+    )
+
+    //endregion
+
+    private val generator = SerializationClassJsonSchemaGenerator()
+
+    @Test
+    fun `should generate schema for recursive sealed hierarchy`() {
+        val schema = generator.generateSchemaString(Tree.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Tree",
+              "type": "object",
+              "properties": {
+                "root": {
+                  "$ref": "#/$defs/Node"
+                }
+              },
+              "required": ["root"],
+              "additionalProperties": false,
+              "$defs": {
+                "Node": {
+                  "oneOf": [
+                    { "$ref": "#/$defs/Branch" },
+                    { "$ref": "#/$defs/Leaf" }
+                  ]
+                },
+                "Branch": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "Branch"
+                    },
+                    "id": { "type": "string" },
+                    "left": {
+                      "oneOf": [
+                        { "type": "null" },
+                        { "$ref": "#/$defs/Node" }
+                      ]
+                    },
+                    "right": {
+                      "$ref": "#/$defs/Node"
+                    }
+                  },
+                  "required": ["type", "id", "left", "right"],
+                  "additionalProperties": false
+                },
+                "Leaf": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "Leaf"
+                    },
+                    "id": { "type": "string" },
+                    "value": { "type": "string" }
+                  },
+                  "required": ["type", "id", "value"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for self-referencing type`() {
+        val schema = generator.generateSchemaString(LinkedNode.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "LinkedNode",
+              "type": "object",
+              "properties": {
+                "value": { "type": "string" },
+                "next": {
+                  "oneOf": [
+                    { "type": "null" },
+                    { "$ref": "#/$defs/LinkedNode" }
+                  ]
+                }
+              },
+              "required": ["value", "next"],
+              "additionalProperties": false,
+              "$defs": {
+                "LinkedNode": {
+                  "type": "object",
+                  "properties": {
+                    "value": { "type": "string" },
+                    "next": {
+                      "oneOf": [
+                        { "type": "null" },
+                        { "$ref": "#/$defs/LinkedNode" }
+                      ]
+                    }
+                  },
+                  "required": ["value", "next"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}

--- a/kotlinx-schema-generator-json/src/jvmTest/kotlin/kotlinx/schema/generator/json/RecursiveTypeReflectionTest.kt
+++ b/kotlinx-schema-generator-json/src/jvmTest/kotlin/kotlinx/schema/generator/json/RecursiveTypeReflectionTest.kt
@@ -1,0 +1,148 @@
+package kotlinx.schema.generator.json
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+
+class RecursiveTypeReflectionTest {
+    //region Test models
+
+    @Suppress("unused")
+    sealed class TreeNode {
+        abstract val id: String
+
+        data class Leaf(
+            override val id: String,
+            val value: String,
+        ) : TreeNode()
+
+        data class Branch(
+            override val id: String,
+            val left: TreeNode?,
+            val right: TreeNode,
+        ) : TreeNode()
+    }
+
+    data class Tree(
+        val root: TreeNode,
+    )
+
+    data class LinkedNode(
+        val value: String,
+        val next: LinkedNode?,
+    )
+
+    //endregion
+
+    private val generator =
+        ReflectionClassJsonSchemaGenerator(
+            json = Json { prettyPrint = true },
+            config = JsonSchemaConfig.Default,
+        )
+
+    @Test
+    fun `should generate schema for recursive sealed hierarchy`() {
+        val schema = generator.generateSchemaString(Tree::class)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.generator.json.RecursiveTypeReflectionTest.Tree",
+              "type": "object",
+              "properties": {
+                "root": {
+                  "$ref": "#/$defs/kotlinx.schema.generator.json.RecursiveTypeReflectionTest.TreeNode"
+                }
+              },
+              "required": ["root"],
+              "additionalProperties": false,
+              "$defs": {
+                "kotlinx.schema.generator.json.RecursiveTypeReflectionTest.TreeNode": {
+                  "oneOf": [
+                    { "$ref": "#/$defs/kotlinx.schema.generator.json.RecursiveTypeReflectionTest.TreeNode.Branch" },
+                    { "$ref": "#/$defs/kotlinx.schema.generator.json.RecursiveTypeReflectionTest.TreeNode.Leaf" }
+                  ]
+                },
+                "kotlinx.schema.generator.json.RecursiveTypeReflectionTest.TreeNode.Branch": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "kotlinx.schema.generator.json.RecursiveTypeReflectionTest.TreeNode.Branch"
+                    },
+                    "id": { "type": "string" },
+                    "left": {
+                      "oneOf": [
+                        { "type": "null" },
+                        { "$ref": "#/$defs/kotlinx.schema.generator.json.RecursiveTypeReflectionTest.TreeNode" }
+                      ]
+                    },
+                    "right": {
+                      "$ref": "#/$defs/kotlinx.schema.generator.json.RecursiveTypeReflectionTest.TreeNode"
+                    }
+                  },
+                  "required": ["type", "id", "left", "right"],
+                  "additionalProperties": false
+                },
+                "kotlinx.schema.generator.json.RecursiveTypeReflectionTest.TreeNode.Leaf": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "kotlinx.schema.generator.json.RecursiveTypeReflectionTest.TreeNode.Leaf"
+                    },
+                    "id": { "type": "string" },
+                    "value": { "type": "string" }
+                  },
+                  "required": ["type", "id", "value"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `should generate schema for self-referencing type`() {
+        val schema = generator.generateSchemaString(LinkedNode::class)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.generator.json.RecursiveTypeReflectionTest.LinkedNode",
+              "type": "object",
+              "properties": {
+                "value": { "type": "string" },
+                "next": {
+                  "oneOf": [
+                    { "type": "null" },
+                    { "$ref": "#/$defs/kotlinx.schema.generator.json.RecursiveTypeReflectionTest.LinkedNode" }
+                  ]
+                }
+              },
+              "required": ["value", "next"],
+              "additionalProperties": false,
+              "$defs": {
+                "kotlinx.schema.generator.json.RecursiveTypeReflectionTest.LinkedNode": {
+                  "type": "object",
+                  "properties": {
+                    "value": { "type": "string" },
+                    "next": {
+                      "oneOf": [
+                        { "type": "null" },
+                        { "$ref": "#/$defs/kotlinx.schema.generator.json.RecursiveTypeReflectionTest.LinkedNode" }
+                      ]
+                    }
+                  },
+                  "required": ["value", "next"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}

--- a/ksp-integration-tests/src/main/kotlin/kotlinx/schema/integration/type/TreeNode.kt
+++ b/ksp-integration-tests/src/main/kotlin/kotlinx/schema/integration/type/TreeNode.kt
@@ -1,0 +1,38 @@
+package kotlinx.schema.integration.type
+
+import kotlinx.schema.Description
+import kotlinx.schema.Schema
+
+@Description("A node in a tree structure")
+@Schema(withSchemaObject = true)
+sealed class TreeNode {
+    @Description("Node identifier")
+    abstract val id: String
+
+    @Description("A leaf node containing a value")
+    @Schema
+    data class Leaf(
+        @Description("Node identifier")
+        override val id: String,
+        @Description("Leaf value")
+        val value: String,
+    ) : TreeNode()
+
+    @Description("A branch node with recursive children")
+    @Schema
+    data class Branch(
+        @Description("Node identifier")
+        override val id: String,
+        @Description("Optional left child")
+        val left: TreeNode?,
+        @Description("Right child")
+        val right: TreeNode,
+    ) : TreeNode()
+}
+
+@Description("A tree with a root node")
+@Schema(withSchemaObject = true)
+data class Tree(
+    @Description("The root node")
+    val root: TreeNode,
+)

--- a/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/type/TreeNodeSchemaTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/type/TreeNodeSchemaTest.kt
@@ -1,0 +1,163 @@
+package kotlinx.schema.integration.type
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlin.test.Test
+
+class TreeNodeSchemaTest {
+    @Test
+    fun `generates schema for tree with recursive sealed hierarchy`() {
+        val schema = Tree::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.integration.type.Tree",
+              "description": "A tree with a root node",
+              "type": "object",
+              "properties": {
+                "root": {
+                  "description": "The root node",
+                  "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode"
+                }
+              },
+              "required": ["root"],
+              "additionalProperties": false,
+              "$defs": {
+                "kotlinx.schema.integration.type.TreeNode": {
+                  "description": "A node in a tree structure",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode.Branch" },
+                    { "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode.Leaf" }
+                  ]
+                },
+                "kotlinx.schema.integration.type.TreeNode.Branch": {
+                  "type": "object",
+                  "description": "A branch node with recursive children",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "kotlinx.schema.integration.type.TreeNode.Branch"
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Node identifier"
+                    },
+                    "left": {
+                      "oneOf": [
+                        { "type": "null" },
+                        { "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode" }
+                      ],
+                      "description": "Optional left child"
+                    },
+                    "right": {
+                      "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode",
+                      "description": "Right child"
+                    }
+                  },
+                  "required": ["type", "id", "left", "right"],
+                  "additionalProperties": false
+                },
+                "kotlinx.schema.integration.type.TreeNode.Leaf": {
+                  "type": "object",
+                  "description": "A leaf node containing a value",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "kotlinx.schema.integration.type.TreeNode.Leaf"
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Node identifier"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "Leaf value"
+                    }
+                  },
+                  "required": ["type", "id", "value"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `generates polymorphic schema for recursive sealed root`() {
+        val schema = TreeNode::class.jsonSchemaString
+
+        // language=json
+        schema shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.integration.type.TreeNode",
+              "description": "A node in a tree structure",
+              "type": "object",
+              "additionalProperties": false,
+              "oneOf": [
+                { "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode.Branch" },
+                { "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode.Leaf" }
+              ],
+              "$defs": {
+                "kotlinx.schema.integration.type.TreeNode": {
+                  "description": "A node in a tree structure",
+                  "oneOf": [
+                    { "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode.Branch" },
+                    { "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode.Leaf" }
+                  ]
+                },
+                "kotlinx.schema.integration.type.TreeNode.Branch": {
+                  "type": "object",
+                  "description": "A branch node with recursive children",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "kotlinx.schema.integration.type.TreeNode.Branch"
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Node identifier"
+                    },
+                    "left": {
+                      "oneOf": [
+                        { "type": "null" },
+                        { "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode" }
+                      ],
+                      "description": "Optional left child"
+                    },
+                    "right": {
+                      "$ref": "#/$defs/kotlinx.schema.integration.type.TreeNode",
+                      "description": "Right child"
+                    }
+                  },
+                  "required": ["type", "id", "left", "right"],
+                  "additionalProperties": false
+                },
+                "kotlinx.schema.integration.type.TreeNode.Leaf": {
+                  "type": "object",
+                  "description": "A leaf node containing a value",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "kotlinx.schema.integration.type.TreeNode.Leaf"
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Node identifier"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "Leaf value"
+                    }
+                  },
+                  "required": ["type", "id", "value"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}


### PR DESCRIPTION
## Summary

- Add recursive type support tests across all three generators (serialization, reflection, KSP) — adapted from PR #195 by @EugeneTheDev
- Route polymorphic subtypes through `ensureNodeInDefinitions` instead of calling `convertNode` directly, unifying cycle protection in a single code path                                                                                              
- Guard discriminator injection with an idempotency check to prevent double `type` property when `convertPolymorphic` runs multiple times for the same sealed hierarchy via recursive references                                                           
- Replace `toMap()` defensive copy in `BaseIntrospectionContext.nodes` with a zero-allocation read-only view
                                                                                                                                  
## Context                                                                                                                    

PR #195 identified that recursive types (e.g. `data class Branch(val left: Node?, val right: Node)` referencing its own sealed parent) could cause issues in schema generation. The current codebase already handles recursion via `withCycleDetection` in introspectors and `ensureNodeInDefinitions` placeholder pattern in the transformer — but had zero test coverage for recursive types and `convertPolymorphic` bypassed the shared cycle-safe registration path.                                              

Cherry-picking/rebasing #195 was not viable due to heavy divergence in TypeGraphToJsonSchemaTransformer`, so the test scenarios were adapted manually and the production code was improved independently.
                                                                                                                                  
## Production changes                                                                                                         

  `TypeGraphToJsonSchemaTransformer.kt` — `convertPolymorphic` now registers subtypes via `ensureNodeInDefinitions` instead of `convertNode` + manual `definitions[typeName] =`. Discriminator injection checks `node.discriminator.name !in registered.properties` to prevent double injection.                                                                             
                                                                                                                                
  `BaseIntrospectionContext.kt` — `nodes` getter returns `_nodes` directly (read-only `Map` interface) instead of `_nodes.toMap()` (full copy).
                                                                                                                                  
## Test coverage                                                                                                              

  - **RecursiveTypeSchemaTest.kt** (commonTest) — Serialization generator: recursive sealed hierarchy (`Tree` → `Node` →  `Branch`/`Leaf`) and self-referencing type (`LinkedNode`)
  - **RecursiveTypeReflectionTest.kt** (jvmTest) — Reflection generator: same two scenarios with `KClass`-based API               
  - **TreeNode.kt + TreeNodeSchemaTest.kt** (ksp-integration-tests) — KSP generator: recursive sealed hierarchy as both wrapped root (`Tree`) and polymorphic root (`TreeNode`)                                                                                 
  - **TypeGraphToJsonSchemaTransformerTest.kt** (commonTest) — Hand-crafted `TypeGraph` tests: error propagation on broken graphs (dangling TypeRef), idempotent discriminator injection when a subtype is referenced both directly and via sealed hierarchy      
   

### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements

