### PR TITLE
feat: support @SerialName in reflection and KSP introspectors with FQN annotation matching (#204)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ apidocs:
 .PHONY: knit
 knit:
 	@echo "🪡🧶 Running Knit check ..."
-	@./gradlew :docs:clean knit knitCheck :docs:test --no-configuration-cache
-	@./gradlew :docs:test
+	@./gradlew :docs:clean knit knitCheck --no-configuration-cache
+	@./gradlew :docs:test --rerun-tasks
 	@echo "✅ Knit check completed!"
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -1204,8 +1204,16 @@ The configuration file is **optional** — if not provided or fails to load, the
 
 By default, the library recognizes:
 
-**Annotation names**: Description, LLMDescription, JsonPropertyDescription, JsonClassDescription, P
-**Attribute names**: value, description
+**Description annotations**: Description, LLMDescription, JsonPropertyDescription, JsonClassDescription, P
+**Description attributes**: value, description
+**Ignore annotations**: SchemaIgnore, SerialSchemaIgnore, JsonIgnoreType
+**Name-override annotations**: kotlinx.serialization.SerialName (matched by fully qualified name)
+**Name-override attributes**: value
+
+> [!NOTE]
+> Annotation names containing a dot (e.g., `kotlinx.serialization.SerialName`) are matched
+> **case-sensitively** against the annotation's fully qualified name. Names without a dot
+> are matched **case-insensitively** by simple name.
 
 #### Adding Custom Annotations
 
@@ -1215,6 +1223,10 @@ To customize, place `kotlinx-schema.properties` in your project's resources:
 # Add your custom annotations to the defaults
 introspector.annotations.description.names=Description,MyCustomAnnotation,DocString
 introspector.annotations.description.attributes=value,description,text
+
+# Name-override annotations (use FQN for precise matching)
+introspector.annotations.name.names=kotlinx.serialization.SerialName
+introspector.annotations.name.attributes=value
 ```
 
 **Note**: The library falls back to built-in defaults if the configuration file is missing or cannot be loaded.

--- a/docs/serializable.md
+++ b/docs/serializable.md
@@ -6,6 +6,9 @@
 * [Overview](#overview)
 * [Setup](#setup)
 * [Basic Usage](#basic-usage)
+* [@SerialName support](#@serialname-support)
+  * [Renaming properties](#renaming-properties)
+  * [Renaming enum entries](#renaming-enum-entries)
 * [Configuration](#configuration)
   * [Introspector configuration](#introspector-configuration)
   * [@SerialDescription support](#@serialdescription-support)
@@ -105,6 +108,110 @@ This code prints:
 
 For custom behavior, construct the generator directly with explicit `introspectorConfig` or `jsonSchemaConfig`.
 
+## @SerialName support
+
+The generator respects `@SerialName` at every level — classes, properties, and enum entries.
+Use it to control the exact names that appear in the generated schema.
+
+### Renaming properties
+
+`@SerialName` on a constructor parameter changes the property key in the schema's `properties` object
+and `required` array:
+
+<!--- CLEAR -->
+<!--- INCLUDE
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+import kotlinx.schema.generator.json.serialization.SerializationClassJsonSchemaGenerator
+import io.kotest.assertions.json.shouldEqualJson
+-->
+```kotlin
+@Serializable
+@SerialName("ApiRequest")
+data class ApiRequest(
+    @SerialName("request_id") val requestId: String,
+    @SerialName("client") val userAgent: String = "unknown",
+    val payload: String,
+)
+```
+
+<!--- INCLUDE
+fun main() {
+-->
+```kotlin
+val schema = SerializationClassJsonSchemaGenerator.Default
+    .generateSchemaString(ApiRequest.serializer().descriptor)
+
+schema shouldEqualJson $$"""
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ApiRequest",
+      "type": "object",
+      "properties": {
+        "request_id": { "type": "string" },
+        "client": { "type": "string" },
+        "payload": { "type": "string" }
+      },
+      "required": ["request_id", "payload"],
+      "additionalProperties": false
+    }
+""".trimIndent()
+```
+<!--- SUFFIX
+}
+-->
+<!--- KNIT example-knit-serializable-02.kt -->
+
+The Kotlin property names (`requestId`, `userAgent`) become `request_id` and `user_agent` in the schema.
+Properties with default values (`userAgent`) remain optional.
+
+### Renaming enum entries
+
+`@SerialName` on enum entries changes the values in the schema's `enum` array:
+
+<!--- CLEAR -->
+<!--- INCLUDE
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+import kotlinx.schema.generator.json.serialization.SerializationClassJsonSchemaGenerator
+import io.kotest.assertions.json.shouldEqualJson
+-->
+```kotlin
+@Serializable
+@SerialName("Priority")
+enum class Priority {
+    @SerialName("p0_critical") CRITICAL,
+    @SerialName("p1_high") HIGH,
+    @SerialName("p2_medium") MEDIUM,
+    @SerialName("p3_low") LOW,
+}
+```
+
+<!--- INCLUDE
+fun main() {
+-->
+```kotlin
+val schema = SerializationClassJsonSchemaGenerator.Default
+    .generateSchemaString(Priority.serializer().descriptor)
+
+schema shouldEqualJson $$"""
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "Priority",
+      "type": "string",
+      "enum": ["p0_critical", "p1_high", "p2_medium", "p3_low"]
+    }
+""".trimIndent()
+```
+<!--- SUFFIX
+}
+-->
+<!--- KNIT example-knit-serializable-03.kt -->
+
+> [!TIP]
+> The reflection-based generator (`ReflectionClassJsonSchemaGenerator`) also respects `@SerialName`
+> on classes, properties, and enum entries — no extra configuration needed.
+
 ## Configuration
 
 `SerializationClassJsonSchemaGenerator` accepts three optional constructor parameters:
@@ -168,7 +275,7 @@ println(schema)
 <!--- SUFFIX
 }
 -->
-<!--- KNIT example-knit-serializable-02.kt -->
+<!--- KNIT example-knit-serializable-04.kt -->
 
 This code prints:
 ```json
@@ -257,7 +364,7 @@ println(schemaString)
 <!--- SUFFIX
 }
 -->
-<!--- KNIT example-knit-serializable-03.kt -->
+<!--- KNIT example-knit-serializable-05.kt -->
 
 This code prints:
 ```json
@@ -335,7 +442,7 @@ println(schemaString)
 <!--- SUFFIX
 }
 -->
-<!--- KNIT example-knit-serializable-04.kt -->
+<!--- KNIT example-knit-serializable-06.kt -->
 
 This code generates:
 ```json
@@ -425,7 +532,7 @@ println(schemaString)
 <!--- SUFFIX
 }
 -->
-<!--- KNIT example-knit-serializable-05.kt -->
+<!--- KNIT example-knit-serializable-07.kt -->
 
 Each subtype gets a required discriminator property containing the subtype's serial name as a constant:
 
@@ -571,7 +678,7 @@ println(schema)
 <!--- SUFFIX
 }
 -->
-<!--- KNIT example-knit-serializable-06.kt -->
+<!--- KNIT example-knit-serializable-08.kt -->
 
 The output follows the same `oneOf` / `$defs` structure as sealed classes. Register only a subset
 of subtypes to produce a schema limited to those types.

--- a/kotlinx-schema-generator-core/api/kotlinx-schema-generator-core.api
+++ b/kotlinx-schema-generator-core/api/kotlinx-schema-generator-core.api
@@ -88,8 +88,10 @@ public final class kotlinx/schema/generator/core/ir/EnumNode : kotlinx/schema/ge
 
 public final class kotlinx/schema/generator/core/ir/Introspections {
 	public static final field INSTANCE Lkotlinx/schema/generator/core/ir/Introspections;
-	public static final fun getDescriptionFromAnnotation (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
-	public static final fun isIgnoreAnnotation (Ljava/lang/String;)Z
+	public static final fun getDescriptionFromAnnotation (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
+	public static final fun getNameOverride (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
+	public static final fun isIgnoreAnnotation (Ljava/lang/String;Ljava/lang/String;)Z
+	public static synthetic fun isIgnoreAnnotation$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Z
 }
 
 public final class kotlinx/schema/generator/core/ir/ListNode : kotlinx/schema/generator/core/ir/TypeNode {

--- a/kotlinx-schema-generator-core/api/kotlinx-schema-generator-core.api
+++ b/kotlinx-schema-generator-core/api/kotlinx-schema-generator-core.api
@@ -312,3 +312,7 @@ public final class kotlinx/schema/generator/reflect/ReflectionFunctionIntrospect
 	public fun introspect (Lkotlin/reflect/KCallable;)Lkotlinx/schema/generator/core/ir/TypeGraph;
 }
 
+public final class kotlinx/schema/generator/reflect/ReflectionUtilsKt {
+	public static final fun extractNameOverride (Ljava/util/List;)Ljava/lang/String;
+}
+

--- a/kotlinx-schema-generator-core/api/kotlinx-schema-generator-core.klib.api
+++ b/kotlinx-schema-generator-core/api/kotlinx-schema-generator-core.klib.api
@@ -350,6 +350,7 @@ final class kotlinx.schema.generator.core.ir/TypeId { // kotlinx.schema.generato
 }
 
 final object kotlinx.schema.generator.core.ir/Introspections { // kotlinx.schema.generator.core.ir/Introspections|null[0]
-    final fun getDescriptionFromAnnotation(kotlin/String, kotlin.collections/List<kotlin/Pair<kotlin/String, kotlin/Any?>>): kotlin/String? // kotlinx.schema.generator.core.ir/Introspections.getDescriptionFromAnnotation|getDescriptionFromAnnotation(kotlin.String;kotlin.collections.List<kotlin.Pair<kotlin.String,kotlin.Any?>>){}[0]
-    final fun isIgnoreAnnotation(kotlin/String): kotlin/Boolean // kotlinx.schema.generator.core.ir/Introspections.isIgnoreAnnotation|isIgnoreAnnotation(kotlin.String){}[0]
+    final fun getDescriptionFromAnnotation(kotlin/String, kotlin/String?, kotlin.collections/List<kotlin/Pair<kotlin/String, kotlin/Any?>>): kotlin/String? // kotlinx.schema.generator.core.ir/Introspections.getDescriptionFromAnnotation|getDescriptionFromAnnotation(kotlin.String;kotlin.String?;kotlin.collections.List<kotlin.Pair<kotlin.String,kotlin.Any?>>){}[0]
+    final fun getNameOverride(kotlin/String, kotlin/String?, kotlin.collections/List<kotlin/Pair<kotlin/String, kotlin/Any?>>): kotlin/String? // kotlinx.schema.generator.core.ir/Introspections.getNameOverride|getNameOverride(kotlin.String;kotlin.String?;kotlin.collections.List<kotlin.Pair<kotlin.String,kotlin.Any?>>){}[0]
+    final fun isIgnoreAnnotation(kotlin/String, kotlin/String? = ...): kotlin/Boolean // kotlinx.schema.generator.core.ir/Introspections.isIgnoreAnnotation|isIgnoreAnnotation(kotlin.String;kotlin.String?){}[0]
 }

--- a/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/Config.kt
+++ b/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/Config.kt
@@ -24,7 +24,7 @@ package kotlinx.schema.generator.core
  */
 internal expect object Config {
     /**
-     * Set of lowercase annotation simple names recognized as description providers.
+     * Ordered list of lowercase annotation simple names recognized as description providers.
      *
      * Annotations are matched case-insensitively by their simple name only (not fully qualified name).
      * This allows recognition of description annotations from multiple frameworks (kotlinx-schema,
@@ -35,14 +35,15 @@ internal expect object Config {
      *
      * Default value: Description, LLMDescription, JsonPropertyDescription, JsonClassDescription, P
      */
-    val descriptionAnnotationNames: Set<String>
+    val descriptionAnnotationNames: List<String>
 
     /**
-     * Set of lowercase parameter names to check for description text.
+     * Ordered list of lowercase parameter names to check for description text.
      *
      * When an annotation matches [descriptionAnnotationNames], its parameters are inspected
      * for these attribute names to extract the description value. The first matching parameter
-     * with a non-null String value is returned.
+     * with a non-null String value is returned. Order determines priority — earlier entries
+     * take precedence.
      *
      * Loaded lazily from the `introspector.annotations.description.attributes` property in
      * `kotlinx-schema.properties`. If loading fails, falls back to built-in defaults.
@@ -53,10 +54,10 @@ internal expect object Config {
      * - For `@Description("User name")`, the "value" parameter contains "User name"
      * - For `@JsonPropertyDescription(description = "User email")`, the "description" parameter contains "User email"
      */
-    val descriptionValueAttributes: Set<String>
+    val descriptionValueAttributes: List<String>
 
     /**
-     * Set of lowercase annotation simple names recognized as ignore markers.
+     * Ordered list of lowercase annotation simple names recognized as ignore markers.
      *
      * Classes annotated with any of these annotations are excluded from schema generation
      * (e.g., sealed subtypes omitted from polymorphic `oneOf` schemas).
@@ -66,5 +67,33 @@ internal expect object Config {
      *
      * Default value: SchemaIgnore, SerialSchemaIgnore, JsonIgnoreType
      */
-    val ignoreAnnotationNames: Set<String>
+    val ignoreAnnotationNames: List<String>
+
+    /**
+     * Ordered list of annotation names recognized as name-override providers (e.g., `@SerialName`).
+     *
+     * Names containing a dot (`.`) are treated as fully qualified names and matched
+     * **case-sensitively** against the annotation's qualified name. Names without a dot
+     * are matched **case-insensitively** against the annotation's simple name.
+     *
+     * Loaded lazily from the `introspector.annotations.name.names` property in
+     * `kotlinx-schema.properties`. If loading fails, falls back to built-in defaults.
+     *
+     * Default value: kotlinx.serialization.SerialName
+     */
+    val nameAnnotationNames: List<String>
+
+    /**
+     * Ordered list of lowercase parameter names to check for name-override text.
+     *
+     * When an annotation matches [nameAnnotationNames], its parameters are inspected
+     * for these attribute names to extract the override name value. Order determines
+     * priority — earlier entries take precedence.
+     *
+     * Loaded lazily from the `introspector.annotations.name.attributes` property in
+     * `kotlinx-schema.properties`. If loading fails, falls back to built-in defaults.
+     *
+     * Default value: "value"
+     */
+    val nameValueAttributes: List<String>
 }

--- a/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/ir/Introspections.kt
+++ b/kotlinx-schema-generator-core/src/commonMain/kotlin/kotlinx/schema/generator/core/ir/Introspections.kt
@@ -2,28 +2,43 @@ package kotlinx.schema.generator.core.ir
 
 import kotlinx.schema.generator.core.Config
 import kotlinx.schema.generator.core.InternalSchemaGeneratorApi
-import kotlinx.schema.generator.core.ir.Introspections.descriptionAnnotationNames
-import kotlinx.schema.generator.core.ir.Introspections.descriptionValueAttributes
 import kotlinx.schema.generator.core.ir.Introspections.getDescriptionFromAnnotation
+import kotlinx.schema.generator.core.ir.Introspections.getNameOverride
 import kotlinx.schema.generator.core.ir.Introspections.isIgnoreAnnotation
 import kotlin.jvm.JvmStatic
 
 /**
- * Utility object for annotation-based introspection, providing methods to process annotations,
- * especially those related to descriptions.
+ * Utility object for annotation-based introspection, providing methods to process annotations
+ * for descriptions, ignore markers, and name overrides.
  *
- * This object provides a configurable mechanism for recognizing description annotations from
- * multiple frameworks (kotlinx-schema, Jackson, LangChain4j, Koog, etc.) by their simple names.
+ * This object provides a configurable mechanism for recognizing annotations from
+ * multiple frameworks (kotlinx-schema, Jackson, LangChain4j, Koog, kotlinx.serialization, etc.)
  * Configuration is loaded from `kotlinx-schema.properties` on the classpath.
+ *
+ * ## Annotation name matching
+ *
+ * Annotation names are matched in two ways depending on the configured name format:
+ *
+ * - **Simple names** (no dots): Matched **case-insensitively** against the annotation's simple name.
+ *   Example: `"Description"` matches `@Description`, `@description`, `@DESCRIPTION`.
+ * - **Fully qualified names** (contains dots): Matched **case-sensitively** against the annotation's
+ *   qualified name. Example: `"kotlinx.serialization.SerialName"` matches only
+ *   `@kotlinx.serialization.SerialName`, not a different `@SerialName` from another package.
  *
  * ## Configuration
  *
- * The annotation detection behavior is controlled by two properties in `kotlinx-schema.properties`:
+ * The annotation detection behavior is controlled by properties in `kotlinx-schema.properties`:
  *
- * - `introspector.annotations.description.names`: Comma-separated list of annotation simple names
+ * - `introspector.annotations.description.names`: Comma-separated list of annotation names
  *   to recognize as description providers (e.g., "Description,LLMDescription,P")
  * - `introspector.annotations.description.attributes`: Comma-separated list of annotation parameter
  *   names that contain description text (e.g., "value,description")
+ * - `introspector.annotations.ignore.names`: Comma-separated list of annotation names
+ *   to recognize as ignore markers (e.g., "SchemaIgnore,JsonIgnoreType")
+ * - `introspector.annotations.name.names`: Comma-separated list of annotation names
+ *   to recognize as name-override providers (e.g., "kotlinx.serialization.SerialName")
+ * - `introspector.annotations.name.attributes`: Comma-separated list of annotation parameter
+ *   names that contain name-override text (e.g., "value")
  *
  * ## Customizing Configuration
  *
@@ -39,110 +54,177 @@ import kotlin.jvm.JvmStatic
  *
  * @see getDescriptionFromAnnotation
  * @see isIgnoreAnnotation
+ * @see getNameOverride
  * @see Config
  */
 @InternalSchemaGeneratorApi
 public object Introspections {
-    /**
-     * Set of lowercase annotation simple names recognized as description providers.
-     *
-     * @see Config.descriptionAnnotationNames
-     */
-    private val descriptionAnnotationNames: Set<String> = Config.descriptionAnnotationNames
+    //region Annotation name sets
 
     /**
-     * Set of lowercase annotation simple names recognized as ignore markers.
+     * Holds pre-split simple and FQN name sets for an annotation category.
      *
-     * @see Config.ignoreAnnotationNames
+     * Simple names are stored lowercase for case-insensitive matching.
+     * FQN names are stored in original case for case-sensitive matching.
      */
-    private val ignoreAnnotationNames: Set<String> = Config.ignoreAnnotationNames
+    private data class AnnotationNameSets(
+        val simpleNames: Set<String>,
+        val fqnNames: Set<String>,
+    )
 
     /**
-     * Set of lowercase annotation parameter names that may contain description text.
+     * Splits a list of annotation names into simple names (lowercase) and FQN names (exact case).
+     * Names containing a dot are treated as fully qualified names.
+     */
+    private fun splitByFqn(names: List<String>): AnnotationNameSets {
+        val simple = mutableSetOf<String>()
+        val fqn = mutableSetOf<String>()
+        for (name in names) {
+            if ('.' in name) fqn.add(name) else simple.add(name.lowercase())
+        }
+        return AnnotationNameSets(simple, fqn)
+    }
+
+    /**
+     * Checks whether an annotation matches a set of recognized names.
+     *
+     * Simple names are matched case-insensitively against [simpleName].
+     * FQN names are matched case-sensitively against [qualifiedName].
+     */
+    private fun matchesAnnotation(
+        simpleName: String,
+        qualifiedName: String?,
+        nameSets: AnnotationNameSets,
+    ): Boolean =
+        simpleName.lowercase() in nameSets.simpleNames ||
+            (qualifiedName != null && qualifiedName in nameSets.fqnNames)
+
+    //endregion
+
+    //region Description annotation config
+
+    private val descriptionNames: AnnotationNameSets by lazy {
+        splitByFqn(Config.descriptionAnnotationNames)
+    }
+
+    /**
+     * Ordered list of lowercase annotation parameter names that may contain description text.
+     * Order determines priority — earlier entries take precedence.
      *
      * @see Config.descriptionValueAttributes
      */
-    private val descriptionValueAttributes: Set<String> = Config.descriptionValueAttributes
+    private val descriptionValueAttributes: List<String> = Config.descriptionValueAttributes
+
+    //endregion
+
+    //region Ignore annotation config
+
+    private val ignoreNames: AnnotationNameSets by lazy {
+        splitByFqn(Config.ignoreAnnotationNames)
+    }
+
+    //endregion
+
+    //region Name-override annotation config
+
+    private val nameNames: AnnotationNameSets by lazy {
+        splitByFqn(Config.nameAnnotationNames)
+    }
+
+    /**
+     * Ordered list of lowercase annotation parameter names that may contain name-override text.
+     * Order determines priority — earlier entries take precedence.
+     *
+     * @see Config.nameValueAttributes
+     */
+    private val nameValueAttributes: List<String> = Config.nameValueAttributes
+
+    //endregion
 
     /**
      * Extracts the description text from an annotation if it matches a recognized description annotation.
      *
-     * This method performs case-insensitive matching of the annotation's simple name against
-     * [descriptionAnnotationNames]. If matched, it searches the annotation's arguments for any
-     * parameter names that match [descriptionValueAttributes] and returns the first non-null
-     * String value found.
+     * Simple annotation names are matched **case-insensitively**; fully qualified names are matched
+     * **case-sensitively** (exact match).
      *
-     * ## Recognition Logic
-     *
-     * 1. The annotation is matched by **simple name only** (not fully qualified name)
-     * 2. Matching is **case-insensitive** for both annotation names and parameter names
-     * 3. The first matching parameter with a non-null String value is returned
-     *
-     * ## Example Usage
-     *
-     * ```kotlin
-     * // With @Description annotation
-     * @Description("A purchasable product with pricing and inventory info.")
-     * class Product
-     *
-     * val description = Introspections.getDescriptionFromAnnotation(
-     *     annotationName = "Description",
-     *     annotationArguments = listOf("value" to "A purchasable product with pricing and inventory info.")
-     * )
-     * // description == "A purchasable product with pricing and inventory info."
-     * ```
-     *
-     * ```kotlin
-     * // With Jackson annotation
-     * @JsonPropertyDescription(description = "User's email address")
-     * val email: String
-     *
-     * val description = Introspections.getDescriptionFromAnnotation(
-     *     annotationName = "JsonPropertyDescription",
-     *     annotationArguments = listOf("description" to "User's email address")
-     * )
-     * // description == "User's email address"
-     * ```
-     *
-     * ## Attribute ordering
-     *
-     * When multiple parameters of the annotation match [descriptionValueAttributes] (e.g., an
-     * annotation with both `value` and `description` fields), the **first non-empty string value**
-     * in the provided `annotationArguments` list is returned. The ordering of
-     * `annotationArguments` is determined by the caller (typically the order in which
-     * `annotationClass.members` enumerates properties via Kotlin reflection, which is not
-     * specified by the Kotlin language and may vary across JVM implementations). In practice this
-     * is only relevant when both fields are non-empty simultaneously, which is an unusual usage.
-     *
-     * @param annotationName The simple name of the annotation to inspect (e.g., "Description", "P")
+     * @param simpleName The simple name of the annotation (e.g., "Description")
+     * @param qualifiedName The fully qualified name of the annotation (e.g., "kotlinx.schema.Description"),
+     *   or null if unavailable
      * @param annotationArguments List of key-value pairs representing the annotation's parameters
      * @return The description text if found, or null if the annotation is not recognized or
      *         contains no matching description parameter
      */
     @JvmStatic
     public fun getDescriptionFromAnnotation(
-        annotationName: String,
+        simpleName: String,
+        qualifiedName: String?,
         annotationArguments: List<Pair<String, Any?>>,
     ): String? =
-        if (annotationName.lowercase() in descriptionAnnotationNames) {
-            annotationArguments
-                .filter { it.first.lowercase() in descriptionValueAttributes }
-                .firstNotNullOfOrNull { (_, value) -> (value as? String)?.takeIf { it.isNotEmpty() } }
+        if (matchesAnnotation(simpleName, qualifiedName, descriptionNames)) {
+            extractFirstStringAttribute(annotationArguments, descriptionValueAttributes)
         } else {
             null
         }
 
     /**
-     * Checks whether the given annotation simple name is recognized as an ignore marker.
+     * Checks whether the given annotation is recognized as an ignore marker.
      *
-     * Matching is case-insensitive by simple name only (not fully qualified name),
-     * following the same convention as [getDescriptionFromAnnotation].
+     * Simple annotation names are matched **case-insensitively**; fully qualified names are matched
+     * **case-sensitively** (exact match).
      *
-     * @param annotationName The simple name of the annotation to check (e.g., "SchemaIgnore", "JsonIgnoreType")
+     * @param simpleName The simple name of the annotation (e.g., "SchemaIgnore")
+     * @param qualifiedName The fully qualified name of the annotation, or null if unavailable
      * @return `true` if the annotation is recognized as an ignore marker
      */
     @JvmStatic
-    public fun isIgnoreAnnotation(annotationName: String): Boolean = annotationName.lowercase() in ignoreAnnotationNames
+    public fun isIgnoreAnnotation(
+        simpleName: String,
+        qualifiedName: String? = null,
+    ): Boolean = matchesAnnotation(simpleName, qualifiedName, ignoreNames)
+
+    /**
+     * Extracts the name-override value from an annotation if it matches a recognized
+     * name-override annotation (e.g., `@SerialName`).
+     *
+     * Simple annotation names are matched **case-insensitively**; fully qualified names are matched
+     * **case-sensitively** (exact match).
+     *
+     * @param simpleName The simple name of the annotation (e.g., "SerialName")
+     * @param qualifiedName The fully qualified name of the annotation
+     *   (e.g., "kotlinx.serialization.SerialName"), or null if unavailable
+     * @param annotationArguments List of key-value pairs representing the annotation's parameters
+     * @return The override name if found, or null if the annotation is not recognized or
+     *         contains no matching name parameter
+     */
+    @JvmStatic
+    public fun getNameOverride(
+        simpleName: String,
+        qualifiedName: String?,
+        annotationArguments: List<Pair<String, Any?>>,
+    ): String? =
+        if (matchesAnnotation(simpleName, qualifiedName, nameNames)) {
+            extractFirstStringAttribute(annotationArguments, nameValueAttributes)
+        } else {
+            null
+        }
+
+    /**
+     * Extracts the first non-empty string value from annotation arguments whose key matches
+     * the given attribute names.
+     *
+     * Iterates [attributeNames] in order, so the first attribute name in the list has the
+     * highest priority. For each attribute name, finds the matching annotation argument and
+     * returns its value if non-empty.
+     */
+    private fun extractFirstStringAttribute(
+        annotationArguments: List<Pair<String, Any?>>,
+        attributeNames: List<String>,
+    ): String? {
+        val argsByName = annotationArguments.associateBy({ it.first.lowercase() }, { it.second })
+        return attributeNames.firstNotNullOfOrNull { attrName ->
+            (argsByName[attrName] as? String)?.takeIf { it.isNotEmpty() }
+        }
+    }
 }
 
 /**

--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/core/Config.jvm.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/core/Config.jvm.kt
@@ -1,6 +1,5 @@
 package kotlinx.schema.generator.core
 
-import kotlinx.schema.generator.core.Config.descriptionAnnotationNames
 import java.io.IOException
 import java.util.Properties
 import kotlin.io.bufferedReader
@@ -10,12 +9,14 @@ private const val CONFIG_FILE_NAME = "kotlinx-schema.properties"
 private const val DESCRIPTION_NAMES_KEY = "introspector.annotations.description.names"
 private const val DESCRIPTION_ATTRIBUTES_KEY = "introspector.annotations.description.attributes"
 private const val IGNORE_NAMES_KEY = "introspector.annotations.ignore.names"
+private const val NAME_NAMES_KEY = "introspector.annotations.name.names"
+private const val NAME_ATTRIBUTES_KEY = "introspector.annotations.name.attributes"
 
 /**
  * Default fallback values if configuration loading fails
  */
 private val DEFAULT_ANNOTATION_NAMES =
-    setOf(
+    listOf(
         "description",
         "llmdescription",
         "jsonpropertydescription",
@@ -27,7 +28,7 @@ private val DEFAULT_ANNOTATION_NAMES =
  * Default fallback values if configuration loading fails
  */
 private val DEFAULT_VALUE_ATTRIBUTES =
-    setOf(
+    listOf(
         "value",
         "description",
     )
@@ -36,15 +37,31 @@ private val DEFAULT_VALUE_ATTRIBUTES =
  * Default fallback values if configuration loading fails
  */
 private val DEFAULT_IGNORE_NAMES =
-    setOf(
+    listOf(
         "schemaignore",
         "serialschemaignore",
         "jsonignoretype",
     )
 
+/**
+ * Default fallback values if configuration loading fails
+ */
+private val DEFAULT_NAME_ANNOTATION_NAMES =
+    listOf(
+        "kotlinx.serialization.SerialName",
+    )
+
+/**
+ * Default fallback values if configuration loading fails
+ */
+private val DEFAULT_NAME_VALUE_ATTRIBUTES =
+    listOf(
+        "value",
+    )
+
 internal actual object Config {
     /**
-     * Set of lowercase annotation simple names recognized as description providers.
+     * Ordered list of lowercase annotation simple names recognized as description providers.
      *
      * Annotations are matched case-insensitively by their simple name only (not fully qualified name).
      * This allows recognition of description annotations from multiple frameworks (kotlinx-schema,
@@ -55,14 +72,14 @@ internal actual object Config {
      *
      * Default value: Description, LLMDescription, JsonPropertyDescription, JsonClassDescription, P
      */
-    actual val descriptionAnnotationNames: Set<String> by lazy {
+    actual val descriptionAnnotationNames: List<String> by lazy {
         loadConfiguration { properties ->
             parseListProperty(properties, DESCRIPTION_NAMES_KEY)
         } ?: DEFAULT_ANNOTATION_NAMES
     }
 
     /**
-     * Set of lowercase parameter names to check for description text.
+     * Ordered list of lowercase parameter names to check for description text.
      *
      * When an annotation matches [descriptionAnnotationNames], its parameters are inspected
      * for these attribute names to extract the description value. The first matching parameter
@@ -77,16 +94,28 @@ internal actual object Config {
      * - For `@Description("User name")`, the "value" parameter contains "User name"
      * - For `@JsonPropertyDescription(description = "User email")`, the "description" parameter contains "User email"
      */
-    actual val descriptionValueAttributes: Set<String> by lazy {
+    actual val descriptionValueAttributes: List<String> by lazy {
         loadConfiguration { properties ->
             parseListProperty(properties, DESCRIPTION_ATTRIBUTES_KEY)
         } ?: DEFAULT_VALUE_ATTRIBUTES
     }
 
-    actual val ignoreAnnotationNames: Set<String> by lazy {
+    actual val ignoreAnnotationNames: List<String> by lazy {
         loadConfiguration { properties ->
             parseListProperty(properties, IGNORE_NAMES_KEY)
         } ?: DEFAULT_IGNORE_NAMES
+    }
+
+    actual val nameAnnotationNames: List<String> by lazy {
+        loadConfiguration { properties ->
+            parseListPropertyPreservingFqnCase(properties, NAME_NAMES_KEY)
+        } ?: DEFAULT_NAME_ANNOTATION_NAMES
+    }
+
+    actual val nameValueAttributes: List<String> by lazy {
+        loadConfiguration { properties ->
+            parseListProperty(properties, NAME_ATTRIBUTES_KEY)
+        } ?: DEFAULT_NAME_VALUE_ATTRIBUTES
     }
 
     private fun <T> loadConfiguration(extractor: (Properties) -> T): T? =
@@ -103,7 +132,7 @@ internal actual object Config {
     private fun parseListProperty(
         properties: Properties,
         key: String,
-    ): Set<String> {
+    ): List<String> {
         val value = properties.getProperty(key)
         require(!value.isNullOrBlank()) {
             "Required property '$key' is missing or empty in $CONFIG_FILE_NAME"
@@ -113,10 +142,36 @@ internal actual object Config {
             .split(',')
             .map { it.trim().lowercase() }
             .filter { it.isNotEmpty() }
-            .toSet()
-            .also { set ->
-                require(set.isNotEmpty()) {
-                    "Property '$key' in $CONFIG_FILE_NAME resulted in empty set after parsing"
+            .distinct()
+            .also { list ->
+                require(list.isNotEmpty()) {
+                    "Property '$key' in $CONFIG_FILE_NAME resulted in empty list after parsing"
+                }
+            }
+    }
+
+    /**
+     * Parses a comma-separated list property, preserving original case for FQN entries
+     * (names containing dots) and lowercasing simple names.
+     */
+    private fun parseListPropertyPreservingFqnCase(
+        properties: Properties,
+        key: String,
+    ): List<String> {
+        val value = properties.getProperty(key)
+        require(!value.isNullOrBlank()) {
+            "Required property '$key' is missing or empty in $CONFIG_FILE_NAME"
+        }
+
+        return value
+            .split(',')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map { name -> if ('.' in name) name else name.lowercase() }
+            .distinct()
+            .also { list ->
+                require(list.isNotEmpty()) {
+                    "Property '$key' in $CONFIG_FILE_NAME resulted in empty list after parsing"
                 }
             }
     }

--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectionContext.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectionContext.kt
@@ -214,20 +214,32 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
     //region Create methods
 
     /**
-     * Creates a [TypeId] from a [KClass], using qualified name or simple name as fallback.
+     * Creates a [TypeId] from a [KClass], using `@SerialName` override if present,
+     * or qualified name / simple name as fallback.
      */
-    private fun createTypeId(klass: KClass<*>): TypeId = TypeId(klass.qualifiedName ?: klass.simpleName ?: "Anonymous")
+    private fun createTypeId(klass: KClass<*>): TypeId {
+        val nameOverride = extractNameOverride(klass.java.annotations.toList())
+        return TypeId(nameOverride ?: klass.qualifiedName ?: klass.simpleName ?: "Anonymous")
+    }
 
     /**
      * Creates an [EnumNode] from an enum [KClass].
+     *
+     * Respects `@SerialName` on the enum class (overrides the class name)
+     * and on individual enum entries (overrides the entry name in the schema).
      */
     private fun createEnumNode(klass: KClass<*>): EnumNode {
         @Suppress("UNCHECKED_CAST")
         val enumConstants = (klass.java as Class<out Enum<*>>).enumConstants
+        val entries = enumConstants.map { constant ->
+            val field = klass.java.getField(constant.name)
+            extractNameOverride(field.annotations.toList()) ?: constant.name
+        }
+        val nameOverride = extractNameOverride(klass.java.annotations.toList())
         return EnumNode(
-            name = klass.simpleName ?: "UnknownEnum",
-            entries = enumConstants.map { it.name },
-            description = extractDescription(klass.annotations),
+            name = nameOverride ?: klass.simpleName ?: "UnknownEnum",
+            entries = entries,
+            description = extractDescription(klass.java.annotations.toList()),
         )
     }
 
@@ -338,11 +350,12 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
                 }
         }
 
+        val nameOverride = extractNameOverride(klass.java.annotations.toList())
         return ObjectNode(
-            name = klass.simpleName ?: "UnknownClass",
+            name = nameOverride ?: klass.simpleName ?: "UnknownClass",
             properties = properties,
             required = requiredProperties,
-            description = extractDescription(klass.annotations),
+            description = extractDescription(klass.java.annotations.toList()),
         )
     }
 
@@ -354,7 +367,8 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
         klass: KClass<*>,
         sealedSubclasses: List<KClass<*>>,
     ): PolymorphicNode {
-        val baseName = klass.simpleName ?: "UnknownSealed"
+        val nameOverride = extractNameOverride(klass.java.annotations.toList())
+        val baseName = nameOverride ?: klass.simpleName ?: "UnknownSealed"
 
         val subtypes =
             sealedSubclasses.map { subclass ->
@@ -378,7 +392,7 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
                     name = "type",
                     mapping = discriminatorMapping,
                 ),
-            description = extractDescription(klass.annotations),
+            description = extractDescription(klass.java.annotations.toList()),
         )
     }
 
@@ -410,17 +424,20 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
         val constructor = findPrimaryConstructor(klass)
 
         constructor?.parameters?.forEach { param ->
-            val propertyName = param.name ?: return@forEach
+            val kotlinName = param.name ?: return@forEach
             val hasDefault = param.isOptional
 
             // Get annotations both on the constructor parameter and property associated with it
-            val annotations = param.annotations + findPropertyByName(klass, propertyName)?.annotations.orEmpty()
+            val annotations = param.annotations + findPropertyByName(klass, kotlinName)?.annotations.orEmpty()
+
+            // Use @SerialName override if present, otherwise use Kotlin property name
+            val propertyName = extractNameOverride(annotations) ?: kotlinName
 
             val propertyType = param.type
             val typeRef = toRef(propertyType)
 
             // Get the actual default value if available
-            val defaultValue = if (hasDefault) defaultValues[propertyName] else null
+            val defaultValue = if (hasDefault) defaultValues[kotlinName] else null
 
             properties +=
                 Property(

--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionUtils.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionUtils.kt
@@ -61,7 +61,11 @@ internal fun isSchemaIgnored(annotations: List<Annotation>): Boolean =
 internal fun extractDescription(annotations: List<Annotation>): String? =
     annotations.firstNotNullOfOrNull { annotation ->
         val javaClass = annotation.annotationClass.java
-        Introspections.getDescriptionFromAnnotation(javaClass.simpleName, javaClass.name, buildAnnotationArgs(annotation))
+        Introspections.getDescriptionFromAnnotation(
+            javaClass.simpleName,
+            javaClass.name,
+            buildAnnotationArgs(annotation),
+        )
     }
 
 /**

--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionUtils.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionUtils.kt
@@ -1,14 +1,13 @@
 package kotlinx.schema.generator.reflect
 
+import kotlinx.schema.generator.core.InternalSchemaGeneratorApi
 import kotlinx.schema.generator.core.ir.Introspections
 import kotlinx.schema.generator.core.ir.TypeRef
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
-import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
-import kotlin.reflect.full.IllegalCallableAccessException
 import kotlin.reflect.full.allSuperclasses
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.javaMethod
@@ -50,8 +49,8 @@ internal fun findPropertyByName(
  */
 internal fun isSchemaIgnored(annotations: List<Annotation>): Boolean =
     annotations.any { annotation ->
-        val name = annotation.annotationClass.simpleName ?: return@any false
-        Introspections.isIgnoreAnnotation(name)
+        val javaClass = annotation.annotationClass.java
+        Introspections.isIgnoreAnnotation(javaClass.simpleName, javaClass.name)
     }
 
 /**
@@ -61,47 +60,44 @@ internal fun isSchemaIgnored(annotations: List<Annotation>): Boolean =
  */
 internal fun extractDescription(annotations: List<Annotation>): String? =
     annotations.firstNotNullOfOrNull { annotation ->
-        val annotationName = annotation.annotationClass.simpleName ?: return@firstNotNullOfOrNull null
-        val annotationArguments =
-            buildList {
-                annotation.annotationClass.members
-                    .filterIsInstance<KProperty1<Annotation, *>>()
-                    .forEach { property ->
-                        val value =
-                            try {
-                                property.get(annotation)
-                            } catch (_: IllegalCallableAccessException) {
-                                fallbackViaJavaReflection(annotation, property) ?: return@forEach
-                            } catch (_: IllegalAccessException) {
-                                fallbackViaJavaReflection(annotation, property) ?: return@forEach
-                            }
-                        add(property.name to value)
-                    }
-            }
-        Introspections.getDescriptionFromAnnotation(annotationName, annotationArguments)
+        val javaClass = annotation.annotationClass.java
+        Introspections.getDescriptionFromAnnotation(javaClass.simpleName, javaClass.name, buildAnnotationArgs(annotation))
     }
 
 /**
- * KProperty1.get() wraps java.lang.IllegalAccessException in
- * kotlin.reflect.full.IllegalCallableAccessException when the annotation
- * interface is non-public (e.g. package-private for Kotlin `internal`
- * annotations from external modules). Fall back to Java reflection on
- * the proxy class, which is always accessible.
- * Returns null when the fallback itself fails; null is safe here because
- * Java annotation elements cannot return null values.
+ * Extracts a name override from annotations (e.g., from `@SerialName`).
+ *
+ * @see [Introspections.getNameOverride]
  */
-private fun fallbackViaJavaReflection(
-    annotation: Annotation,
-    property: KProperty1<Annotation, *>,
-): Any? =
-    try {
-        val javaMethod = annotation.javaClass.getDeclaredMethod(property.name)
-        javaMethod.isAccessible = true
-        javaMethod.invoke(annotation)
-    } catch (_: ReflectiveOperationException) {
-        null
-    } catch (_: SecurityException) {
-        null
+@InternalSchemaGeneratorApi
+public fun extractNameOverride(annotations: List<Annotation>): String? =
+    annotations.firstNotNullOfOrNull { annotation ->
+        val javaClass = annotation.annotationClass.java
+        Introspections.getNameOverride(javaClass.simpleName, javaClass.name, buildAnnotationArgs(annotation))
+    }
+
+/**
+ * Builds key-value pairs from an annotation's elements for use with [Introspections] methods.
+ *
+ * Uses Java reflection via [Class.getDeclaredMethods] to reliably access annotation elements,
+ * including annotations from external modules where Kotlin reflection metadata may be unavailable.
+ */
+private fun buildAnnotationArgs(annotation: Annotation): List<Pair<String, Any?>> =
+    buildList {
+        annotation.annotationClass.java.declaredMethods
+            .filter { it.parameterCount == 0 }
+            .forEach { method ->
+                val value =
+                    try {
+                        method.isAccessible = true
+                        method.invoke(annotation)
+                    } catch (_: ReflectiveOperationException) {
+                        return@forEach
+                    } catch (_: SecurityException) {
+                        return@forEach
+                    }
+                add(method.name to value)
+            }
     }
 
 /**

--- a/kotlinx-schema-generator-core/src/jvmMain/resources/kotlinx-schema.properties
+++ b/kotlinx-schema-generator-core/src/jvmMain/resources/kotlinx-schema.properties
@@ -34,3 +34,15 @@ introspector.annotations.description.attributes=value,description
 ## - SerialSchemaIgnore (kotlinx-schema, serialization-aware)
 ## - JsonIgnoreType (Jackson)
 introspector.annotations.ignore.names=SchemaIgnore,SerialSchemaIgnore,JsonIgnoreType
+
+## Annotation names recognized as name-override providers
+## Names containing a dot are treated as fully qualified names (FQN) and matched case-sensitively.
+## Names without a dot are matched case-insensitively by simple name.
+##
+## Default annotations supported:
+## - kotlinx.serialization.SerialName (kotlinx.serialization, matched by FQN)
+introspector.annotations.name.names=kotlinx.serialization.SerialName
+
+## Annotation parameter names that contain name-override text
+## Format: Comma-separated list (case-insensitive matching)
+introspector.annotations.name.attributes=value

--- a/kotlinx-schema-generator-core/src/jvmTest/kotlin/kotlinx/schema/generator/core/ir/IntrospectionsTest.kt
+++ b/kotlinx-schema-generator-core/src/jvmTest/kotlin/kotlinx/schema/generator/core/ir/IntrospectionsTest.kt
@@ -6,7 +6,9 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 class IntrospectionsTest {
-    //region Single-element annotation
+
+    //region Description extraction — simple name matching
+
     @ParameterizedTest
     @CsvSource(
         "Description, value",
@@ -21,21 +23,22 @@ class IntrospectionsTest {
         attribute: String,
     ) {
         Introspections.getDescriptionFromAnnotation(
-            annotationName = name,
+            simpleName = name,
+            qualifiedName = null,
             listOf(attribute to "My Description"),
         ) shouldBe "My Description"
     }
+
     //endregion
 
     //region Multi-element LLMDescription regression
+
     @Test
     fun `extracts description from LLMDescription with description= style when value is empty`() {
-        // Regression: @LLMDescription has both value and description fields;
-        // when used as @LLMDescription(description = "text"), value defaults to ""
-        // and should not shadow the non-empty description field.
         val result =
             Introspections.getDescriptionFromAnnotation(
-                annotationName = "LLMDescription",
+                simpleName = "LLMDescription",
+                qualifiedName = null,
                 annotationArguments = listOf("value" to "", "description" to "Product identifier"),
             )
         result shouldBe "Product identifier"
@@ -43,40 +46,51 @@ class IntrospectionsTest {
 
     @Test
     fun `extracts description from LLMDescription with value= shorthand style`() {
-        // @LLMDescription("Product name") sets value="Product name", description=""
         val result =
             Introspections.getDescriptionFromAnnotation(
-                annotationName = "LLMDescription",
+                simpleName = "LLMDescription",
+                qualifiedName = null,
                 annotationArguments = listOf("value" to "Product name", "description" to ""),
             )
         result shouldBe "Product name"
     }
+
+    @Test
+    fun `attribute priority follows config order regardless of annotation argument order`() {
+        // Config attribute order is: value, description
+        // Annotation argument order has "description" first, but "value" should win because
+        // it has higher priority in the config
+        val result =
+            Introspections.getDescriptionFromAnnotation(
+                simpleName = "LLMDescription",
+                qualifiedName = null,
+                annotationArguments = listOf("description" to "lower priority", "value" to "higher priority"),
+            )
+        result shouldBe "higher priority"
+    }
+
     //endregion
 
-    //region Negative cases
-    @Test
-    fun `returns null for unrecognized annotation name`() {
+    //region Description negative cases
+
+    @ParameterizedTest
+    @CsvSource(
+        "UnknownAnnotation, value, Some text",
+        "Description, unknownAttr, Some text",
+        "Description, value, ''",
+    )
+    fun `getDescriptionFromAnnotation returns null for non-matching cases`(
+        name: String,
+        attribute: String,
+        text: String,
+    ) {
         Introspections.getDescriptionFromAnnotation(
-            annotationName = "UnknownAnnotation",
-            annotationArguments = listOf("value" to "Some text"),
+            simpleName = name,
+            qualifiedName = null,
+            annotationArguments = listOf(attribute to text),
         ) shouldBe null
     }
 
-    @Test
-    fun `returns null when no recognized attribute name matches`() {
-        Introspections.getDescriptionFromAnnotation(
-            annotationName = "Description",
-            annotationArguments = listOf("unknownAttr" to "Some text"),
-        ) shouldBe null
-    }
-
-    @Test
-    fun `returns null for empty string description value`() {
-        Introspections.getDescriptionFromAnnotation(
-            annotationName = "Description",
-            annotationArguments = listOf("value" to ""),
-        ) shouldBe null
-    }
     //endregion
 
     //region Ignore annotation recognition
@@ -113,6 +127,68 @@ class IntrospectionsTest {
     )
     fun `does not match unrecognized annotation names as ignore`(name: String) {
         Introspections.isIgnoreAnnotation(name) shouldBe false
+    }
+
+    //endregion
+
+    //region FQN matching — backward compatibility
+
+    @Test
+    fun `simple-name description annotation still matches when qualifiedName is provided`() {
+        Introspections.getDescriptionFromAnnotation(
+            simpleName = "Description",
+            qualifiedName = "kotlinx.schema.Description",
+            annotationArguments = listOf("value" to "test"),
+        ) shouldBe "test"
+    }
+
+    @Test
+    fun `simple-name ignore annotation still matches when qualifiedName is provided`() {
+        Introspections.isIgnoreAnnotation(
+            simpleName = "SchemaIgnore",
+            qualifiedName = "kotlinx.schema.SchemaIgnore",
+        ) shouldBe true
+    }
+
+    //endregion
+
+    //region Name override extraction
+
+    @ParameterizedTest
+    @CsvSource(
+        "SerialName, kotlinx.serialization.SerialName, custom_name, custom_name",
+        "SerialName, kotlinx.serialization.SerialName, user_email, user_email",
+    )
+    fun `getNameOverride extracts value when FQN matches`(
+        simpleName: String,
+        qualifiedName: String,
+        inputValue: String,
+        expectedResult: String,
+    ) {
+        Introspections.getNameOverride(
+            simpleName = simpleName,
+            qualifiedName = qualifiedName,
+            annotationArguments = listOf("value" to inputValue),
+        ) shouldBe expectedResult
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "SomeOther, com.example.SomeOther, custom_name",
+        "SerialName, , custom_name",
+        "serialname, kotlinx.serialization.serialname, custom_name",
+        "SerialName, kotlinx.serialization.SerialName, ''",
+    )
+    fun `getNameOverride returns null for non-matching cases`(
+        simpleName: String,
+        qualifiedName: String?,
+        inputValue: String,
+    ) {
+        Introspections.getNameOverride(
+            simpleName = simpleName,
+            qualifiedName = qualifiedName?.takeIf { it.isNotEmpty() },
+            annotationArguments = listOf("value" to inputValue),
+        ) shouldBe null
     }
 
     //endregion

--- a/kotlinx-schema-generator-core/src/nativeMain/kotlin/kotlinx/schema/generator/core/Config.native.kt
+++ b/kotlinx-schema-generator-core/src/nativeMain/kotlin/kotlinx/schema/generator/core/Config.native.kt
@@ -1,10 +1,14 @@
 package kotlinx.schema.generator.core
 
 internal actual object Config {
-    actual val descriptionAnnotationNames: Set<String>
-        get() = setOf("Description")
-    actual val descriptionValueAttributes: Set<String>
-        get() = setOf("value", "description")
-    actual val ignoreAnnotationNames: Set<String>
-        get() = setOf("schemaignore")
+    actual val descriptionAnnotationNames: List<String>
+        get() = listOf("Description")
+    actual val descriptionValueAttributes: List<String>
+        get() = listOf("value", "description")
+    actual val ignoreAnnotationNames: List<String>
+        get() = listOf("schemaignore")
+    actual val nameAnnotationNames: List<String>
+        get() = listOf("kotlinx.serialization.SerialName")
+    actual val nameValueAttributes: List<String>
+        get() = listOf("value")
 }

--- a/kotlinx-schema-generator-core/src/webMain/kotlin/kotlinx/schema/generator/core/Config.web.kt
+++ b/kotlinx-schema-generator-core/src/webMain/kotlin/kotlinx/schema/generator/core/Config.web.kt
@@ -1,10 +1,14 @@
 package kotlinx.schema.generator.core
 
 internal actual object Config {
-    actual val descriptionAnnotationNames: Set<String>
-        get() = setOf("Description")
-    actual val descriptionValueAttributes: Set<String>
-        get() = setOf("value", "description")
-    actual val ignoreAnnotationNames: Set<String>
-        get() = setOf("schemaignore")
+    actual val descriptionAnnotationNames: List<String>
+        get() = listOf("Description")
+    actual val descriptionValueAttributes: List<String>
+        get() = listOf("value", "description")
+    actual val ignoreAnnotationNames: List<String>
+        get() = listOf("schemaignore")
+    actual val nameAnnotationNames: List<String>
+        get() = listOf("kotlinx.serialization.SerialName")
+    actual val nameValueAttributes: List<String>
+        get() = listOf("value")
 }

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerialNameAnnotationTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerialNameAnnotationTest.kt
@@ -1,0 +1,108 @@
+package kotlinx.schema.generator.json.serialization
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+
+class SerialNameAnnotationTest {
+    //region Test models
+
+    @Serializable
+    @SerialName("PersonRecord")
+    data class PersonWithRenamedProperties(
+        val id: Int,
+        @SerialName("user_name") val userName: String,
+        @SerialName("email_address") val emailAddress: String = "n/a",
+    )
+
+    @Serializable
+    @SerialName("Priority")
+    @Suppress("unused")
+    enum class PriorityWithRenamedEntries {
+        @SerialName("p0_critical")
+        CRITICAL,
+
+        @SerialName("p1_high")
+        HIGH,
+
+        @SerialName("p2_low")
+        LOW,
+    }
+
+    @Serializable
+    @SerialName("TaskWithPriority")
+    data class TaskWithPriority(
+        val title: String,
+        val priority: PriorityWithRenamedEntries,
+    )
+
+    //endregion
+
+    private val generator = SerializationClassJsonSchemaGenerator()
+
+    @Test
+    fun `SerialName on properties produces custom keys in properties and required`() {
+        val schema = generator.generateSchemaString(PersonWithRenamedProperties.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "PersonRecord",
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer" },
+                "user_name": { "type": "string" },
+                "email_address": { "type": "string" }
+              },
+              "required": ["id", "user_name"],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `SerialName on enum entries produces custom values in enum array`() {
+        val schema = generator.generateSchemaString(PriorityWithRenamedEntries.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Priority",
+              "type": "string",
+              "enum": ["p0_critical", "p1_high", "p2_low"]
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `SerialName on enum class affects defs key and ref target`() {
+        val schema = generator.generateSchemaString(TaskWithPriority.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "TaskWithPriority",
+              "type": "object",
+              "properties": {
+                "title": { "type": "string" },
+                "priority": { "$ref": "#/$defs/Priority" }
+              },
+              "required": ["title", "priority"],
+              "additionalProperties": false,
+              "$defs": {
+                "Priority": {
+                  "type": "string",
+                  "enum": ["p0_critical", "p1_high", "p2_low"]
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}

--- a/kotlinx-schema-generator-json/src/jvmMain/kotlin/kotlinx/schema/generator/json/ReflectionClassJsonObjectSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/jvmMain/kotlin/kotlinx/schema/generator/json/ReflectionClassJsonObjectSchemaGenerator.kt
@@ -2,6 +2,7 @@ package kotlinx.schema.generator.json
 
 import kotlinx.schema.generator.core.AbstractSchemaGenerator
 import kotlinx.schema.generator.reflect.ReflectionClassIntrospector
+import kotlinx.schema.generator.reflect.extractNameOverride
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KClass
@@ -34,7 +35,11 @@ public class ReflectionClassJsonObjectSchemaGenerator(
         config = JsonSchemaConfig.Default,
     )
 
-    override fun getRootName(target: KClass<out Any>): String = target.qualifiedName ?: target.simpleName ?: "Anonymous"
+    override fun getRootName(target: KClass<out Any>): String =
+        extractNameOverride(target.java.annotations.toList())
+            ?: target.qualifiedName
+            ?: target.simpleName
+            ?: "Anonymous"
 
     override fun targetType(): KClass<KClass<out Any>> = KClass::class
 

--- a/kotlinx-schema-generator-json/src/jvmMain/kotlin/kotlinx/schema/generator/json/ReflectionClassJsonSchemaGenerator.kt
+++ b/kotlinx-schema-generator-json/src/jvmMain/kotlin/kotlinx/schema/generator/json/ReflectionClassJsonSchemaGenerator.kt
@@ -2,6 +2,7 @@ package kotlinx.schema.generator.json
 
 import kotlinx.schema.generator.core.AbstractSchemaGenerator
 import kotlinx.schema.generator.reflect.ReflectionClassIntrospector
+import kotlinx.schema.generator.reflect.extractNameOverride
 import kotlinx.schema.json.JsonSchema
 import kotlinx.serialization.json.Json
 import kotlin.reflect.KClass
@@ -33,7 +34,11 @@ public class ReflectionClassJsonSchemaGenerator(
         config = JsonSchemaConfig.Strict,
     )
 
-    override fun getRootName(target: KClass<out Any>): String = target.qualifiedName ?: target.simpleName ?: "Anonymous"
+    override fun getRootName(target: KClass<out Any>): String =
+        extractNameOverride(target.java.annotations.toList())
+            ?: target.qualifiedName
+            ?: target.simpleName
+            ?: "Anonymous"
 
     override fun targetType(): KClass<KClass<out Any>> = KClass::class
 

--- a/kotlinx-schema-generator-json/src/jvmTest/kotlin/kotlinx/schema/generator/json/SerialNameReflectionTest.kt
+++ b/kotlinx-schema-generator-json/src/jvmTest/kotlin/kotlinx/schema/generator/json/SerialNameReflectionTest.kt
@@ -1,0 +1,109 @@
+package kotlinx.schema.generator.json
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+
+class SerialNameReflectionTest {
+
+    //region Test models
+
+    @Serializable
+    @SerialName("PersonRecord")
+    data class PersonWithRenamedProperties(
+        val id: Int,
+        @property:SerialName("user_name") val userName: String,
+        @property:SerialName("email_address") val emailAddress: String = "n/a",
+    )
+
+    @Serializable
+    @SerialName("Priority")
+    @Suppress("unused")
+    enum class PriorityWithRenamedEntries {
+        @SerialName("p0_critical")
+        CRITICAL,
+
+        @SerialName("p1_high")
+        HIGH,
+
+        @SerialName("p2_low")
+        LOW,
+    }
+
+    @Serializable
+    @SerialName("TaskWithPriority")
+    data class TaskWithPriority(
+        val title: String,
+        val priority: PriorityWithRenamedEntries,
+    )
+
+    //endregion
+
+    private val generator = ReflectionClassJsonSchemaGenerator()
+
+    @Test
+    fun `@SerialName on properties produces custom keys in properties and required`() {
+        val schema = generator.generateSchemaString(PersonWithRenamedProperties::class)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "PersonRecord",
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer" },
+                "user_name": { "type": "string" },
+                "email_address": { "type": "string" }
+              },
+              "required": ["id", "user_name", "email_address"],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `@SerialName on enum entries produces custom values in enum array`() {
+        val schema = generator.generateSchemaString(PriorityWithRenamedEntries::class)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Priority",
+              "type": "string",
+              "enum": ["p0_critical", "p1_high", "p2_low"]
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `@SerialName on enum class affects defs key and ref target`() {
+        val schema = generator.generateSchemaString(TaskWithPriority::class)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "TaskWithPriority",
+              "type": "object",
+              "properties": {
+                "title": { "type": "string" },
+                "priority": { "$ref": "#/$defs/Priority" }
+              },
+              "required": ["title", "priority"],
+              "additionalProperties": false,
+              "$defs": {
+                "Priority": {
+                  "type": "string",
+                  "enum": ["p0_critical", "p1_high", "p2_low"]
+                }
+              }
+            }
+            """.trimIndent()
+    }
+}

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspIntrospectionContext.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspIntrospectionContext.kt
@@ -134,8 +134,9 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
             // Process each sealed subclass
             sealedSubclasses.forEach { toRef(it.asType(emptyList())) }
 
+            val sealedNameOverride = extractNameOverride(decl)
             kotlinx.schema.generator.core.ir.PolymorphicNode(
-                baseName = decl.simpleName.asString(),
+                baseName = sealedNameOverride ?: decl.simpleName.asString(),
                 subtypes = subtypes,
                 discriminator =
                     kotlinx.schema.generator.core.ir.Discriminator(
@@ -172,11 +173,12 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                 decl.declarations
                     .filterIsInstance<KSClassDeclaration>()
                     .filter { it.classKind == com.google.devtools.ksp.symbol.ClassKind.ENUM_ENTRY }
-                    .map { it.simpleName.asString() }
+                    .map { entry -> extractNameOverride(entry) ?: entry.simpleName.asString() }
                     .toList()
 
+            val nameOverride = extractNameOverride(decl)
             kotlinx.schema.generator.core.ir.EnumNode(
-                name = decl.qualifiedName?.asString() ?: decl.simpleName.asString(),
+                name = nameOverride ?: decl.qualifiedName?.asString() ?: decl.simpleName.asString(),
                 entries = entries,
                 description = extractDescription(decl) { decl.descriptionFromKdoc() },
             )
@@ -240,8 +242,9 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
             extractConstructorOrProperties(decl, ::addProperty)
             extractInheritedSealedProperties(decl, processedProperties, ::addProperty)
 
+            val nameOverride = extractNameOverride(decl)
             ObjectNode(
-                name = decl.qualifiedName?.asString() ?: decl.simpleName.asString(),
+                name = nameOverride ?: decl.qualifiedName?.asString() ?: decl.simpleName.asString(),
                 properties = props,
                 required = required,
                 description = extractDescription(decl) { decl.descriptionFromKdoc() },
@@ -259,22 +262,24 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
         val params = decl.primaryConstructor?.parameters.orEmpty()
         if (params.isNotEmpty()) {
             params.forEach { p ->
-                val name = p.name?.asString() ?: return@forEach
-                val description = extractConstructorParamDescription(p, name, decl.docString)
-                addProperty(name, p.type.resolve(), description, p.hasDefault)
+                val kotlinName = p.name?.asString() ?: return@forEach
+                val propertyName = extractNameOverride(p) ?: kotlinName
+                val description = extractConstructorParamDescription(p, kotlinName, decl.docString)
+                addProperty(propertyName, p.type.resolve(), description, p.hasDefault)
             }
         } else {
             decl.getDeclaredProperties().filter { it.isPublic() }.forEach { prop ->
-                val name = prop.simpleName.asString()
+                val kotlinName = prop.simpleName.asString()
+                val propertyName = extractNameOverride(prop) ?: kotlinName
                 val description =
                     extractPropertyDescription(
                         annotated = prop,
-                        propertyName = name,
+                        propertyName = kotlinName,
                         parentKdoc = decl.docString,
                         kdocTagName = "property",
                         elementKdocFallback = { prop.descriptionFromKdoc() },
                     )
-                addProperty(name, prop.type.resolve(), description, false)
+                addProperty(propertyName, prop.type.resolve(), description, false)
             }
         }
     }

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspUtils.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspUtils.kt
@@ -6,6 +6,18 @@ import kotlinx.schema.generator.core.ir.Property
 import kotlinx.schema.generator.core.ir.TypeRef
 
 /**
+ * Extracts a name override from an annotated element's annotations.
+ *
+ * Used to support annotations like `@SerialName` that override the default name
+ * of classes, properties, or enum entries in the generated schema.
+ *
+ * @param annotated The annotated element to inspect
+ * @return The override name if found, or null if no name-override annotation is present
+ */
+internal fun extractNameOverride(annotated: KSAnnotated): String? =
+    annotated.annotations.firstNotNullOfOrNull { it.nameOverrideOrNull() }
+
+/**
  * Extracts description from annotations with KDoc fallback.
  *
  * Unifies the description extraction pattern used across introspectors:

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/descriptions.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/descriptions.kt
@@ -13,11 +13,9 @@ import kotlinx.schema.generator.core.ir.Introspections
  * @return The description extracted from the annotation or null if no description is found.
  */
 internal fun KSAnnotation.descriptionOrNull(): String? {
-    val annotationName =
-        annotationType
-            .resolve()
-            .declaration.simpleName
-            .asString()
+    val declaration = annotationType.resolve().declaration
+    val simpleName = declaration.simpleName.asString()
+    val qualifiedName = declaration.qualifiedName?.asString()
 
     val args: List<Pair<String, Any?>> =
         arguments.mapNotNull {
@@ -26,7 +24,33 @@ internal fun KSAnnotation.descriptionOrNull(): String? {
         }
 
     return Introspections.getDescriptionFromAnnotation(
-        annotationName = annotationName,
+        simpleName = simpleName,
+        qualifiedName = qualifiedName,
+        annotationArguments = args,
+    )
+}
+
+/**
+ * Retrieves the name-override value from the annotation, if available.
+ *
+ * Used to extract custom names from annotations like `@SerialName`.
+ *
+ * @return The name override extracted from the annotation or null if not a name-override annotation.
+ */
+internal fun KSAnnotation.nameOverrideOrNull(): String? {
+    val declaration = annotationType.resolve().declaration
+    val simpleName = declaration.simpleName.asString()
+    val qualifiedName = declaration.qualifiedName?.asString()
+
+    val args: List<Pair<String, Any?>> =
+        arguments.mapNotNull {
+            val name = it.name?.asString() ?: return@mapNotNull null
+            name to it.value
+        }
+
+    return Introspections.getNameOverride(
+        simpleName = simpleName,
+        qualifiedName = qualifiedName,
         annotationArguments = args,
     )
 }

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/ignore.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/ignore.kt
@@ -8,17 +8,16 @@ import kotlinx.schema.generator.core.ir.Introspections
  * (e.g., `@SchemaIgnore`, `@SerialSchemaIgnore`, `@JsonIgnoreType`).
  *
  * Recognition is delegated to [Introspections.isIgnoreAnnotation], which performs
- * case-insensitive matching by simple name against a configurable set loaded
- * from `kotlinx-schema.properties`.
+ * matching against a configurable set loaded from `kotlinx-schema.properties`.
+ * Simple names are matched case-insensitively; fully qualified names are matched
+ * case-sensitively.
  *
  * @return `true` if any annotation on this symbol is recognized as an ignore marker
  */
 internal fun KSAnnotated.isSchemaIgnored(): Boolean =
     annotations.any { annotation ->
-        val name =
-            annotation.annotationType
-                .resolve()
-                .declaration.simpleName
-                .asString()
-        Introspections.isIgnoreAnnotation(name)
+        val declaration = annotation.annotationType.resolve().declaration
+        val simpleName = declaration.simpleName.asString()
+        val qualifiedName = declaration.qualifiedName?.asString()
+        Introspections.isIgnoreAnnotation(simpleName, qualifiedName)
     }

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/type.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/type.kt
@@ -10,12 +10,16 @@ import kotlinx.schema.generator.core.ir.TypeId
  * Generates a stable identifier for a type definition.
  *
  * The method constructs a `TypeId` for the given `KSClassDeclaration`, which is used
- * for deduplication and $ref linking in type schemas. If the class has a qualified name,
- * it is used; otherwise, the simple name is used as a fallback.
+ * for deduplication and $ref linking in type schemas. If the class has a `@SerialName`
+ * annotation, its value is used. Otherwise, the qualified name is used, or the simple
+ * name as a fallback.
  *
  * @return A `TypeId` representing the identifier of the type.
  */
-internal fun KSClassDeclaration.typeId(): TypeId = TypeId(qualifiedName?.asString() ?: simpleName.asString())
+internal fun KSClassDeclaration.typeId(): TypeId {
+    val nameOverride = extractNameOverride(this)
+    return TypeId(nameOverride ?: qualifiedName?.asString() ?: simpleName.asString())
+}
 
 /**
  * Checks if a KSType represents a sealed class and returns the declaration if so.


### PR DESCRIPTION
## Description

- Add FQN-aware annotation matching to `Introspections` — names with dots are matched case-sensitively against qualified names,
  simple names remain case-insensitive
- Add `getNameOverride()` to extract rename values from annotations like `@SerialName`
- Wire `@SerialName` support into reflection and KSP introspectors for class names, property names, enum entries, sealed      
  subtypes, and `$id`/`$defs`/`$ref` in generated schemas
- Change `Config` properties from `Set<String>` to `List<String>` to preserve priority ordering from `kotlinx-schema.properties`
- Switch `buildAnnotationArgs` from Kotlin reflection to Java reflection for reliable annotation access from external modules
- Promote `extractNameOverride` to `@InternalSchemaGeneratorApi public` and reuse in `ReflectionClassJsonSchemaGenerator` and
  `ReflectionClassJsonObjectSchemaGenerator`
- Add serialization generator test coverage for property-level and enum-entry-level `@SerialName` (previously zero coverage)

**Related Issues:** Fixes #204


### Pre-Submission Checklist

- [x] **Self-reviewed** my own code
- [x] **Tests added/updated** and passing locally
- [x] **Documentation updated** (if needed: README, code comments, etc.)
- [x] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [ ] **Breaking changes documented** (if applicable)
- [x] **No debug code**: Removed commented-out code and debug statements

