### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ ksp.useKSP2=true
 detekt.use.worker.api = true
 
 group=org.jetbrains.kotlinx
-version=0.4.5-SNAPSHOT
+version=0.5.0
 
 versionSuffix=SNAPSHOT
 


### PR DESCRIPTION
bump version to 0.5.0