### PR TITLE
Support `JsonClassDiscriminator` annotation for kotlinx-serialization

### DIFF
--- a/docs/serializable.md
+++ b/docs/serializable.md
@@ -486,8 +486,11 @@ This code generates:
 
 ## Polymorphic types
 
-Both sealed and open polymorphic hierarchies are supported. The generator reads the discriminator
-name from `Json.classDiscriminator` and produces `oneOf` schemas with `$defs` for each subtype.
+Both sealed and open polymorphic hierarchies are supported. By default, the generator reads the
+discriminator name from `Json.classDiscriminator` and produces `oneOf` schemas with `$defs` for
+each subtype. If a polymorphic base class is annotated with `@JsonClassDiscriminator("...")`,
+that class-level annotation takes precedence over the global `Json.classDiscriminator` value for
+that specific sealed or polymorphic base.
 
 ### Sealed polymorphism
 

--- a/docs/serializable.md
+++ b/docs/serializable.md
@@ -515,8 +515,11 @@ This code generates:
 
 ## Polymorphic types
 
-Both sealed and open polymorphic hierarchies are supported. The generator reads the discriminator
-name from `Json.classDiscriminator` and produces `oneOf` schemas with `$defs` for each subtype.
+Both sealed and open polymorphic hierarchies are supported. By default, the generator reads the
+discriminator name from `Json.classDiscriminator` and produces `oneOf` schemas with `$defs` for
+each subtype. If a polymorphic base class is annotated with `@JsonClassDiscriminator("...")`,
+that class-level annotation takes precedence over the global `Json.classDiscriminator` value for
+that specific sealed or polymorphic base.
 
 ### Sealed polymorphism
 

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.modules.SerializersModuleCollector
 import kotlin.reflect.KClass
 import kotlinx.serialization.descriptors.PrimitiveKind as SerialPrimitiveKind
@@ -312,8 +313,8 @@ internal class SerializationIntrospectionContext(
                     .sortedBy { it.serialName }
                     .map { SubtypeRef(TypeId(it.serialName)) }
 
-            // Get discriminator configuration from Json
-            val discriminatorName = json.configuration.classDiscriminator
+            // Get discriminator configuration from Json or JsonClassDiscriminator annotation
+            val discriminatorName = descriptor.polymorphicDiscriminatorName()
 
             val discriminator =
                 Discriminator(
@@ -490,6 +491,12 @@ internal class SerializationIntrospectionContext(
         descriptor: SerialDescriptor,
         index: Int,
     ): String? = config.descriptionExtractor.extract(descriptor.getElementAnnotations(index))
+
+    private fun SerialDescriptor.polymorphicDiscriminatorName(): String =
+        annotations
+            .filterIsInstance<JsonClassDiscriminator>()
+            .firstOrNull()
+            ?.discriminator ?: json.configuration.classDiscriminator
 
     /**
      * Returns a new [TypeRef] with the specified nullable flag.

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.modules.SerializersModuleCollector
 import kotlin.reflect.KClass
 import kotlinx.serialization.descriptors.PrimitiveKind as SerialPrimitiveKind
@@ -306,8 +307,8 @@ internal class SerializationIntrospectionContext(
                     .sortedBy { it.serialName }
                     .map { SubtypeRef(TypeId(it.serialName)) }
 
-            // Get discriminator configuration from Json
-            val discriminatorName = json.configuration.classDiscriminator
+            // Get discriminator configuration from Json or JsonClassDiscriminator annotation
+            val discriminatorName = descriptor.polymorphicDiscriminatorName()
 
             val discriminator =
                 Discriminator(
@@ -484,6 +485,12 @@ internal class SerializationIntrospectionContext(
         descriptor: SerialDescriptor,
         index: Int,
     ): String? = config.descriptionExtractor.extract(descriptor.getElementAnnotations(index))
+
+    private fun SerialDescriptor.polymorphicDiscriminatorName(): String =
+        annotations
+            .filterIsInstance<JsonClassDiscriminator>()
+            .firstOrNull()
+            ?.discriminator ?: json.configuration.classDiscriminator
 
     /**
      * Returns a new [TypeRef] with the specified nullable flag.

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SealedPolymorphismSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SealedPolymorphismSchemaGeneratorTest.kt
@@ -3,11 +3,13 @@
 package kotlinx.schema.generator.json.serialization
 
 import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.schema.generator.json.JsonSchemaConfig
 import kotlinx.schema.generator.json.SerialDescription
 import kotlinx.schema.generator.json.SerialSchemaIgnore
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
@@ -31,6 +33,23 @@ class SealedPolymorphismSchemaGeneratorTest {
         data class Rect(
             @property:SerialDescription("Rectangle width") val w: Double,
         ) : Shape()
+    }
+
+    @Serializable
+    @SerialName("Button")
+    @JsonClassDiscriminator("buttonType")
+    sealed class Button {
+        @Serializable
+        @SerialName("BIG")
+        data class BigButton(
+            val title: String,
+        ) : Button()
+
+        @Serializable
+        @SerialName("SMALL")
+        data class SmallButton(
+            val icon: String,
+        ) : Button()
     }
 
     @Test
@@ -141,6 +160,54 @@ class SealedPolymorphismSchemaGeneratorTest {
                     "w": { "type": "number", "description": "Rectangle width" }
                   },
                   "required": ["type", "w"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `sealed class uses JsonClassDiscriminator annotation in schema`() {
+        val generator =
+            SerializationClassJsonSchemaGenerator(
+                jsonSchemaConfig = JsonSchemaConfig.OpenAPI,
+            )
+
+        val schema = generator.generateSchemaString(Button.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Button",
+              "type": "object",
+              "additionalProperties": false,
+              "oneOf": [
+                { "$ref": "#/$defs/BIG" },
+                { "$ref": "#/$defs/SMALL" }
+              ],
+              "discriminator": {
+                "propertyName": "buttonType"
+              },
+              "$defs": {
+                "BIG": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": { "type": "string", "const": "BIG" },
+                    "title": { "type": "string" }
+                  },
+                  "required": ["buttonType", "title"],
+                  "additionalProperties": false
+                },
+                "SMALL": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": { "type": "string", "const": "SMALL" },
+                    "icon": { "type": "string" }
+                  },
+                  "required": ["buttonType", "icon"],
                   "additionalProperties": false
                 }
               }

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SealedPolymorphismSchemaGeneratorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SealedPolymorphismSchemaGeneratorTest.kt
@@ -1,11 +1,13 @@
 package kotlinx.schema.generator.json.serialization
 
 import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.schema.generator.json.JsonSchemaConfig
 import kotlinx.schema.generator.json.SerialDescription
 import kotlinx.schema.generator.json.SerialSchemaIgnore
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
@@ -29,6 +31,23 @@ class SealedPolymorphismSchemaGeneratorTest {
         data class Rect(
             @property:SerialDescription("Rectangle width") val w: Double,
         ) : Shape()
+    }
+
+    @Serializable
+    @SerialName("Button")
+    @JsonClassDiscriminator("buttonType")
+    sealed class Button {
+        @Serializable
+        @SerialName("BIG")
+        data class BigButton(
+            val title: String,
+        ) : Button()
+
+        @Serializable
+        @SerialName("SMALL")
+        data class SmallButton(
+            val icon: String,
+        ) : Button()
     }
 
     @Test
@@ -139,6 +158,54 @@ class SealedPolymorphismSchemaGeneratorTest {
                     "w": { "type": "number", "description": "Rectangle width" }
                   },
                   "required": ["type", "w"],
+                  "additionalProperties": false
+                }
+              }
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `sealed class uses JsonClassDiscriminator annotation in schema`() {
+        val generator =
+            SerializationClassJsonSchemaGenerator(
+                jsonSchemaConfig = JsonSchemaConfig.OpenAPI,
+            )
+
+        val schema = generator.generateSchemaString(Button.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "Button",
+              "type": "object",
+              "additionalProperties": false,
+              "oneOf": [
+                { "$ref": "#/$defs/BIG" },
+                { "$ref": "#/$defs/SMALL" }
+              ],
+              "discriminator": {
+                "propertyName": "buttonType"
+              },
+              "$defs": {
+                "BIG": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": { "type": "string", "const": "BIG" },
+                    "title": { "type": "string" }
+                  },
+                  "required": ["buttonType", "title"],
+                  "additionalProperties": false
+                },
+                "SMALL": {
+                  "type": "object",
+                  "properties": {
+                    "buttonType": { "type": "string", "const": "SMALL" },
+                    "icon": { "type": "string" }
+                  },
+                  "required": ["buttonType", "icon"],
                   "additionalProperties": false
                 }
               }

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
@@ -15,6 +15,7 @@ import kotlinx.schema.generator.core.ir.PrimitiveNode
 import kotlinx.schema.generator.core.ir.TypeId
 import kotlinx.schema.generator.core.ir.TypeRef
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.serializer
 import kotlin.test.Test
 import kotlinx.schema.generator.json.serialization.SerializationClassSchemaIntrospector as SerializationIntrospector
@@ -67,6 +68,20 @@ class SerializationIntrospectorTest {
             val width: Double,
             val height: Double,
         ) : Shape()
+    }
+
+    @Serializable
+    @JsonClassDiscriminator("buttonType")
+    sealed class DiscriminatedButton {
+        @Serializable
+        data class BigButton(
+            val title: String,
+        ) : DiscriminatedButton()
+
+        @Serializable
+        data class SmallButton(
+            val icon: String,
+        ) : DiscriminatedButton()
     }
 
     @Serializable
@@ -204,6 +219,18 @@ class SerializationIntrospectorTest {
 
         subtypeIds.forEach { id ->
             graph.nodes[TypeId(id)].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
+        }
+    }
+
+    @Test
+    fun `introspects JsonClassDiscriminator annotation for sealed polymorphic`() {
+        val graph = introspector.introspect(DiscriminatedButton.serializer().descriptor)
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val polyNode = graph.nodes[rootRef.id].shouldNotBeNull().shouldBeInstanceOf<PolymorphicNode>()
+
+        polyNode.discriminator shouldNotBeNull {
+            name shouldBe "buttonType"
         }
     }
 

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectorTest.kt
@@ -15,6 +15,7 @@ import kotlinx.schema.generator.core.ir.PrimitiveNode
 import kotlinx.schema.generator.core.ir.TypeId
 import kotlinx.schema.generator.core.ir.TypeRef
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.serializer
 import kotlin.test.Test
 import kotlinx.schema.generator.json.serialization.SerializationClassSchemaIntrospector as SerializationIntrospector
@@ -82,6 +83,20 @@ class SerializationIntrospectorTest {
             val width: Double,
             val height: Double,
         ) : Shape()
+    }
+
+    @Serializable
+    @JsonClassDiscriminator("buttonType")
+    sealed class DiscriminatedButton {
+        @Serializable
+        data class BigButton(
+            val title: String,
+        ) : DiscriminatedButton()
+
+        @Serializable
+        data class SmallButton(
+            val icon: String,
+        ) : DiscriminatedButton()
     }
 
     @Serializable
@@ -287,6 +302,18 @@ class SerializationIntrospectorTest {
 
         subtypeIds.forEach { id ->
             graph.nodes[TypeId(id)].shouldNotBeNull().shouldBeInstanceOf<ObjectNode>()
+        }
+    }
+
+    @Test
+    fun `introspects JsonClassDiscriminator annotation for sealed polymorphic`() {
+        val graph = introspector.introspect(DiscriminatedButton.serializer().descriptor)
+
+        val rootRef = graph.root.shouldBeInstanceOf<TypeRef.Ref>()
+        val polyNode = graph.nodes[rootRef.id].shouldNotBeNull().shouldBeInstanceOf<PolymorphicNode>()
+
+        polyNode.discriminator shouldNotBeNull {
+            name shouldBe "buttonType"
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes and their purpose -->

This PR adds support for the `JsonClassDiscriminator` annotation when using kotlinx-serialization. This allows for discriminator names to be set on a per-class basis. For example:

```kotlin
@Serializable
@JsonClassDiscriminator("buttonType")
sealed class Button {
    @Serializable
    @SerialName("BIG")
    data class BigButton(val title: String) : Button()

    @Serializable
    @SerialName("SMALL")
    data class SmallButton(val icon: String) : Button()
}
```

**Breaking changes**: Since the `JsonClassDescription` annotation was previously ignored, this will change the behavior of projects that currently use that annotation. We could add a configuration option to account for that, but since (I think) this is a bug and the new behavior is more expected, it can be changed as-is.

It's worth noting that the annotation is technically [marked as experimental](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-class-discriminator/), but [it was added five years ago](https://github.com/Kotlin/kotlinx.serialization/blame/6956af2e6073347c7832c3c5b374fa3b5a345956/formats/json/commonMain/src/kotlinx/serialization/json/JsonAnnotations.kt#L59) and seemingly hasn't changed since, so I think we can rely on it being stable.

**Related Issues:** <!-- Fixes #123, Closes #456 -->
Fixes #323

---

## Before You Submit

### About PR Size
_Smaller PRs lead to faster reviews, shorter feedback cycles, and better code quality.
Large PRs (500+ lines) are harder to review thoroughly and increase the risk of bugs slipping through._

**Aim for PRs under 200 lines when possible.**
If your PR is large, consider splitting it into focused, incremental changes.

### Pre-Submission Checklist

- [X] **Self-reviewed** my own code
- [X] **Tests added/updated** and passing locally
- [X] **Documentation updated** (if needed: README, code comments, etc.)
- [X] **Focused PR**: Single concern, no unrelated changes or "drive-by" fixes
- [X] **Breaking changes documented** (if applicable)
- [X] **No debug code**: Removed commented-out code and debug statements

---

## Reviewer Guidelines

### Review Philosophy
Following Google's principle: **Approve if this PR improves the codebase**, even if it's not perfect.

- [The Standard of Code Review](https://github.com/google/eng-practices/blob/master/review/reviewer/standard.md)
- [What to look for](https://github.com/google/eng-practices/blob/master/review/reviewer/looking-for.md)

**For Reviewers:**
- [ ] Does this improve the codebase overall?
- [ ] Are there any critical issues that block approval?
- [ ] Can remaining improvements be addressed in follow-up PRs?

---

## Additional Notes
<!-- Any additional information that reviewers should know -->

This only updates the serialization-based version of the schema generator. I see there's already `TODO` to get the same functionality with KSP, but that can be done separately.

---

<!--
Thank you for contributing!
Remember: Smaller PRs → Faster reviews → Shorter cycles → Better outcomes
-->