### PR TITLE
docs: simplify Gradle plugin setup

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,7 @@ C4Context
         System(kxsGenJson, "kotlinx-schema-generator-json")
         System(kxsJsn, "kotlinx-schema-json")
         System(kxsKsp, "kotlinx-schema-ksp")
-        System(kxsGradle, "kotlinx-schema-gradle-plugin")
+        System(kxsGradle, "kotlinx-schema-ksp-gradle-plugin")
     }
 
     Rel(kxsGenJson, kxsGenCore, "uses")
@@ -135,7 +135,7 @@ Top-level modules you might interact with:
 - **kotlinx-schema-ksp** — KSP processor that scans your code and generates the extension properties:
     - `KClass<T>.jsonSchema: JsonObject`
     - `KClass<T>.jsonSchemaString: String`
-- **kotlinx-schema-gradle-plugin** — Gradle plugin (id: "org.jetbrains.kotlinx.schema.ksp") that:
+- **kotlinx-schema-ksp-gradle-plugin** — Gradle plugin (id: "org.jetbrains.kotlinx.schema.ksp") that:
     - Applies KSP automatically
     - Adds the KSP processor dependency
     - Wires generated sources into your source sets

--- a/docs/ksp.md
+++ b/docs/ksp.md
@@ -81,21 +81,16 @@ sourceSets.main.kotlin.srcDir("build/generated/ksp/main/kotlin")
 The plugin automatically handles KSP configuration, source set registration, and task dependencies,
 and provides additional configuration options (DSL) for schema generation.
 
-1. Register the plugin in `settings.gradle.kts`:
+The plugin is published to Maven Central (not the Gradle Plugin Portal), so `mavenCentral()`
+must be available for plugin resolution.
+
+1. Add `mavenCentral()` to `settings.gradle.kts`:
 
     ```kotlin
     pluginManagement {
         repositories {
             google()
             mavenCentral()
-        }
-        
-        resolutionStrategy {
-            eachPlugin {
-                if (requested.id.id == "org.jetbrains.kotlinx.schema.ksp") {
-                    useModule("org.jetbrains.kotlinx:kotlinx-schema-gradle-plugin:<version>")
-                }
-            }
         }
     }
     ```
@@ -107,7 +102,7 @@ and provides additional configuration options (DSL) for schema generation.
 ```kotlin
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.kotlinx.schema.ksp")
+    id("org.jetbrains.kotlinx.schema.ksp") version "<version>"
 }
 
 kotlin {
@@ -127,7 +122,7 @@ kotlinxSchema {
 ```kotlin
 plugins {
     kotlin("jvm")
-    id("org.jetbrains.kotlinx.schema.ksp")
+    id("org.jetbrains.kotlinx.schema.ksp") version "<version>"
 }
 
 dependencies {

--- a/kotlinx-schema-ksp-gradle-plugin/README.md
+++ b/kotlinx-schema-ksp-gradle-plugin/README.md
@@ -64,7 +64,7 @@ build.gradle.kts:
 plugins {
     kotlin("jvm") version "<kotlin-version>"
     kotlin("plugin.serialization") version "<kotlin-version>"
-    id("org.jetbrains.kotlinx.schema.ksp")
+    id("org.jetbrains.kotlinx.schema.ksp") version "<version>"
 }
 
 dependencies {
@@ -82,12 +82,9 @@ kotlinxSchema {
 settings.gradle.kts:
 ```kotlin
 pluginManagement {
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "org.jetbrains.kotlinx.schema.ksp") {
-                useModule("org.jetbrains.kotlinx:kotlinx-schema-gradle-plugin:${providers.gradleProperty("kotlinxSchemaVersion").get()}")
-            }
-        }
+    repositories {
+        google()
+        mavenCentral()
     }
 }
 ```
@@ -103,7 +100,7 @@ kotlinxSchemaVersion=<version>
 plugins {
     kotlin("multiplatform") version "<kotlin-version>"
     kotlin("plugin.serialization") version "<kotlin-version>" 
-    id("org.jetbrains.kotlinx.schema.ksp")
+    id("org.jetbrains.kotlinx.schema.ksp") version "<version>"
 }
 
 kotlin {


### PR DESCRIPTION
The Kotlinx-Schema Gradle plugin and its plugin marker are published to Maven Central. Gradle resolves the `plugins {}` block from `mavenCentral()` directly (verified against `org.jetbrains.kotlinx.schema.ksp` `0.5.0`), so the `resolutionStrategy { eachPlugin { useModule(...) } }` workaround is unnecessary.

That workaround also referenced `kotlinx-schema-gradle-plugin`, an artifact that stopped at `0.0.3`; the current one is `kotlinx-schema-ksp-gradle-plugin`.

### Changes
- `docs/ksp.md`, `kotlinx-schema-ksp-gradle-plugin/README.md`: drop the `resolutionStrategy`/`useModule` block; apply the plugin via `plugins { id("org.jetbrains.kotlinx.schema.ksp") version "<version>" }` with `mavenCentral()` in `pluginManagement`.
- `docs/architecture.md`: fix stale module name `kotlinx-schema-gradle-plugin` → `kotlinx-schema-ksp-gradle-plugin`.

Closes #35.