### PR TITLE
fix: support kotlinx.serialization.json built-in types (#338)

### DIFF
--- a/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectionContext.kt
+++ b/kotlinx-schema-generator-core/src/jvmMain/kotlin/kotlinx/schema/generator/reflect/ReflectionIntrospectionContext.kt
@@ -63,6 +63,10 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
             return TypeRef.Inline(AnyNode(), nullable)
         }
 
+        // Intercept kotlinx.serialization.json types before primitive/serializer/collection handling,
+        // so JsonPrimitive isn't coerced to a string and JsonObject/JsonArray get any-typed elements.
+        jsonBuiltinRefFor(klass, nullable)?.let { return it }
+
         // Try to convert to primitive type
         primitiveNodeFor(klass)?.let { primitiveNode ->
             val ref = TypeRef.Inline(primitiveNode, nullable)
@@ -141,6 +145,36 @@ internal class ReflectionIntrospectionContext : BaseIntrospectionContext<KType>(
         SerialPrimitiveKind.DOUBLE -> PrimitiveKind.DOUBLE
         else -> null
     }
+
+    /**
+     * kotlinx.serialization.json built-in types → schema, or null otherwise. Matched by FQN so core
+     * needs no dependency on serialization-json. `JsonElement`/`JsonPrimitive`/`JsonNull` → [AnyNode];
+     * `JsonObject` → `Map<String, any>`; `JsonArray` → `List<any>`.
+     */
+    private fun jsonBuiltinRefFor(
+        klass: KClass<*>,
+        nullable: Boolean,
+    ): TypeRef? =
+        when (klass.qualifiedName) {
+            "kotlinx.serialization.json.JsonElement",
+            "kotlinx.serialization.json.JsonPrimitive",
+            "kotlinx.serialization.json.JsonNull",
+            -> TypeRef.Inline(AnyNode(), nullable)
+
+            "kotlinx.serialization.json.JsonObject" ->
+                TypeRef.Inline(
+                    MapNode(
+                        key = TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING), false),
+                        value = TypeRef.Inline(AnyNode(), false),
+                    ),
+                    nullable,
+                )
+
+            "kotlinx.serialization.json.JsonArray" ->
+                TypeRef.Inline(ListNode(TypeRef.Inline(AnyNode(), false)), nullable)
+
+            else -> null
+        }
 
     /**
      * Set of value-class [KType]s currently being flattened, used to break the recursion for a

--- a/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
+++ b/kotlinx-schema-generator-json/src/commonMain/kotlin/kotlinx/schema/generator/json/serialization/SerializationIntrospectionContext.kt
@@ -62,7 +62,7 @@ internal class SerializationIntrospectionContext(
 
         val nullable = type.isNullable
 
-        // kotlin.Any / java.lang.Object: any value — emit empty schema {}
+        // Any value (kotlin.Any, JSON element types, …) — emit empty schema {}
         if (type.serialName.removeSuffix("?") in ANY_SERIAL_NAMES) {
             return TypeRef.Inline(AnyNode(), nullable)
         }
@@ -364,14 +364,23 @@ internal class SerializationIntrospectionContext(
         }
 
     private fun extractSealedSubtypes(descriptor: SerialDescriptor): List<SerialDescriptor> {
-        require(descriptor.elementsCount >= 2 && descriptor.getElementName(1) == "value") {
-            "Unexpected sealed descriptor structure: expected 'value' element at index 1, " +
-                "but found '${descriptor.getElementName(1)}'"
+        // The compiler emits sealed classes as a ['type', 'value'] wrapper with subtypes under 'value'.
+        // Any other SEALED shape is a hand-written serializer we can't map to a discriminated `oneOf`.
+        require(descriptor.isStandardSealedWrapper()) {
+            "Cannot derive a polymorphic schema for sealed descriptor '${descriptor.serialName}': " +
+                "not the standard ['type', 'value'] wrapper (elements: ${descriptor.elementNames()})."
         }
 
         val valueDescriptor = descriptor.getElementDescriptor(1)
         return (0 until valueDescriptor.elementsCount).map { valueDescriptor.getElementDescriptor(it) }
     }
+
+    /** The compiler's sealed wrapper: element[0] `type` (discriminator) + element[1] `value`. */
+    private fun SerialDescriptor.isStandardSealedWrapper(): Boolean =
+        elementsCount >= 2 && getElementName(0) == "type" && getElementName(1) == "value"
+
+    private fun SerialDescriptor.elementNames(): List<String> =
+        (0 until elementsCount).map { getElementName(it) }
 
     /**
      * Extracts subtype descriptors for open polymorphic types by querying the
@@ -465,8 +474,18 @@ internal class SerializationIntrospectionContext(
         TypeId(descriptor.unwrapSerialName().removeSuffix("?"))
 
     private companion object {
-        /** Serial names that represent "any value" — mapped to [AnyNode] (empty schema `{}`). */
-        val ANY_SERIAL_NAMES = setOf("kotlin.Any", "java.lang.Object")
+        /**
+         * Serial names mapped to [AnyNode] (empty schema `{}`): `kotlin.Any`/`java.lang.Object` and the
+         * kotlinx.serialization.json "any value" types. `JsonObject`/`JsonArray` are intentionally
+         * excluded — their MAP/LIST handlers already emit precise `object`/`array` schemas.
+         */
+        val ANY_SERIAL_NAMES = setOf(
+            "kotlin.Any",
+            "java.lang.Object",
+            "kotlinx.serialization.json.JsonElement",
+            "kotlinx.serialization.json.JsonPrimitive",
+            "kotlinx.serialization.json.JsonNull",
+        )
     }
 
     /**

--- a/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/JsonBuiltinTypesSchemaTest.kt
+++ b/kotlinx-schema-generator-json/src/commonTest/kotlin/kotlinx/schema/generator/json/serialization/JsonBuiltinTypesSchemaTest.kt
@@ -1,0 +1,77 @@
+package kotlinx.schema.generator.json.serialization
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.schema.generator.core.ir.AnyNode
+import kotlinx.schema.generator.core.ir.MapNode
+import kotlinx.schema.generator.core.ir.ObjectNode
+import kotlinx.schema.generator.core.ir.TypeRef
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+
+/** Regression for #338: the serialization introspector crashed on built-in kotlinx.serialization JSON types. */
+class JsonBuiltinTypesSchemaTest {
+    @Serializable
+    data class AllJsonTypes(
+        val element: JsonElement,
+        val obj: JsonObject,
+        val arr: JsonArray,
+        val prim: JsonPrimitive,
+        val nullableElement: JsonElement?,
+    )
+
+    private val generator = SerializationClassJsonSchemaGenerator()
+
+    @Test
+    fun `Should generate schema for built-in kotlinx serialization JSON types`() {
+        val schema = generator.generateSchemaString(AllJsonTypes.serializer().descriptor)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.generator.json.serialization.JsonBuiltinTypesSchemaTest.AllJsonTypes",
+              "type": "object",
+              "properties": {
+                "element": {},
+                "obj": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "arr": {
+                  "type": "array",
+                  "items": {}
+                },
+                "prim": {},
+                "nullableElement": {}
+              },
+              "additionalProperties": false,
+              "required": [
+                "element",
+                "obj",
+                "arr",
+                "prim",
+                "nullableElement"
+              ]
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `Should introspect JsonElement as AnyNode and JsonObject as Map to Any`() {
+        val graph = SerializationClassSchemaIntrospector().introspect(AllJsonTypes.serializer().descriptor)
+        val root = graph.nodes[(graph.root as TypeRef.Ref).id].shouldBeInstanceOf<ObjectNode>()
+
+        val element = root.properties.first { it.name == "element" }.type.shouldBeInstanceOf<TypeRef.Inline>()
+        element.node.shouldBeInstanceOf<AnyNode>()
+
+        val obj = root.properties.first { it.name == "obj" }.type.shouldBeInstanceOf<TypeRef.Inline>()
+        val map = obj.node.shouldBeInstanceOf<MapNode>()
+        map.value.shouldBeInstanceOf<TypeRef.Inline>().node.shouldBeInstanceOf<AnyNode>()
+    }
+}

--- a/kotlinx-schema-generator-json/src/jvmTest/kotlin/kotlinx/schema/generator/json/JsonBuiltinTypesReflectionTest.kt
+++ b/kotlinx-schema-generator-json/src/jvmTest/kotlin/kotlinx/schema/generator/json/JsonBuiltinTypesReflectionTest.kt
@@ -1,0 +1,57 @@
+package kotlinx.schema.generator.json
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+
+/** Reflection counterpart of the serialization #338 test (reflection mis-generated these types). */
+class JsonBuiltinTypesReflectionTest {
+    data class AllJsonTypes(
+        val element: JsonElement,
+        val obj: JsonObject,
+        val arr: JsonArray,
+        val prim: JsonPrimitive,
+        val nullableElement: JsonElement?,
+    )
+
+    private val generator = ReflectionClassJsonSchemaGenerator.Default
+
+    @Test
+    fun `Should generate schema for built-in kotlinx serialization JSON types via reflection`() {
+        val schema = generator.generateSchemaString(AllJsonTypes::class)
+
+        schema shouldEqualJson
+            // language=JSON
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.generator.json.JsonBuiltinTypesReflectionTest.AllJsonTypes",
+              "type": "object",
+              "properties": {
+                "element": {},
+                "obj": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "arr": {
+                  "type": "array",
+                  "items": {}
+                },
+                "prim": {},
+                "nullableElement": {}
+              },
+              "additionalProperties": false,
+              "required": [
+                "element",
+                "obj",
+                "arr",
+                "prim",
+                "nullableElement"
+              ]
+            }
+            """.trimIndent()
+    }
+}

--- a/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspIntrospectionContext.kt
+++ b/kotlinx-schema-ksp/src/main/kotlin/kotlinx/schema/ksp/ir/KspIntrospectionContext.kt
@@ -9,7 +9,11 @@ import com.google.devtools.ksp.symbol.Nullability
 
 import kotlinx.schema.generator.core.ir.AnyNode
 import kotlinx.schema.generator.core.ir.BaseIntrospectionContext
+import kotlinx.schema.generator.core.ir.ListNode
+import kotlinx.schema.generator.core.ir.MapNode
 import kotlinx.schema.generator.core.ir.ObjectNode
+import kotlinx.schema.generator.core.ir.PrimitiveKind
+import kotlinx.schema.generator.core.ir.PrimitiveNode
 import kotlinx.schema.generator.core.ir.Property
 import kotlinx.schema.generator.core.ir.TypeRef
 
@@ -24,10 +28,12 @@ import kotlinx.schema.generator.core.ir.TypeRef
  *
  * Resolution strategy (applied in order):
  * 1. Basic types (primitives and collections) via [resolveBasicTypeOrNull]
- * 2. Generic type parameters and unknowns -> kotlin.Any via [handleAnyFallback]
- * 3. Sealed class hierarchies -> PolymorphicNode via [handleSealedClass]
- * 4. Enum classes -> EnumNode via [handleEnum]
- * 5. Regular objects/classes -> ObjectNode via [handleObjectOrClass]
+ * 2. `kotlinx.serialization.json` DOM collections (`JsonObject`/`JsonArray`) via [resolveJsonCollectionTypeOrNull]
+ * 3. Opaque JSON values (`JsonElement`/`JsonPrimitive`/`JsonNull`) -> AnyNode via [resolveOpaqueTypeOrNull]
+ * 4. Generic type parameters and unknowns -> kotlin.Any via [handleAnyFallback]
+ * 5. Sealed class hierarchies -> PolymorphicNode via [handleSealedClass]
+ * 6. Enum classes -> EnumNode via [handleEnum]
+ * 7. Regular objects/classes -> ObjectNode via [handleObjectOrClass]
  */
 internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
     /**
@@ -50,6 +56,8 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
         // Try each handler in order, using elvis operator chain for single return
         return requireNotNull(
             resolveBasicTypeOrNull(type)
+                ?: resolveJsonCollectionTypeOrNull(type)
+                ?: resolveOpaqueTypeOrNull(type)
                 ?: handleAnyFallback(type)
                 ?: handleSealedClass(type, nullable)
                 ?: handleEnum(type, nullable)
@@ -76,6 +84,36 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
         // Try primitive types first, then collections, using elvis operator chain
         return KspTypeMappers.primitiveFor(type)?.let { TypeRef.Inline(it, nullable) }
             ?: KspTypeMappers.collectionTypeRefOrNull(type, ::toRef)
+    }
+
+    /**
+     * `JsonObject` → [MapNode] of `String` → any; `JsonArray` → [ListNode] of any. Built directly
+     * (matched by FQN) because KSP can't resolve external supertype type-arguments. Null otherwise.
+     */
+    private fun resolveJsonCollectionTypeOrNull(type: KSType): TypeRef? {
+        val nullable = type.nullability == Nullability.NULLABLE
+        return when (type.declaration.qualifiedName?.asString()) {
+            "kotlinx.serialization.json.JsonObject" ->
+                TypeRef.Inline(
+                    MapNode(
+                        key = TypeRef.Inline(PrimitiveNode(PrimitiveKind.STRING)),
+                        value = TypeRef.Inline(AnyNode()),
+                    ),
+                    nullable,
+                )
+
+            "kotlinx.serialization.json.JsonArray" ->
+                TypeRef.Inline(ListNode(element = TypeRef.Inline(AnyNode())), nullable)
+
+            else -> null
+        }
+    }
+
+    /** [OPAQUE_JSON_SERIAL_NAMES] (`JsonElement`/`JsonPrimitive`/`JsonNull`) → [AnyNode] (`{}`); null otherwise. */
+    private fun resolveOpaqueTypeOrNull(type: KSType): TypeRef? {
+        val nullable = type.nullability == Nullability.NULLABLE
+        val qualifiedName = type.declaration.qualifiedName?.asString() ?: return null
+        return if (qualifiedName in OPAQUE_JSON_SERIAL_NAMES) TypeRef.Inline(AnyNode(), nullable) else null
     }
 
     /**
@@ -317,5 +355,15 @@ internal class KspIntrospectionContext : BaseIntrospectionContext<KSType>() {
                 }
             }
         }
+    }
+
+    private companion object {
+        /** JSON value types → [AnyNode] (`{}`); kept in sync with the other introspectors (#338). */
+        val OPAQUE_JSON_SERIAL_NAMES: Set<String> =
+            setOf(
+                "kotlinx.serialization.json.JsonElement",
+                "kotlinx.serialization.json.JsonPrimitive",
+                "kotlinx.serialization.json.JsonNull",
+            )
     }
 }

--- a/ksp-integration-tests/src/main/kotlin/kotlinx/schema/integration/type/BuiltInJsonTypes.kt
+++ b/ksp-integration-tests/src/main/kotlin/kotlinx/schema/integration/type/BuiltInJsonTypes.kt
@@ -1,0 +1,17 @@
+package kotlinx.schema.integration.type
+
+import kotlinx.schema.Schema
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+// Fixture for #338. Non-KDoc comment so KSP doesn't emit it as the schema description.
+@Schema
+data class BuiltInJsonTypes(
+    val element: JsonElement,
+    val obj: JsonObject,
+    val arr: JsonArray,
+    val prim: JsonPrimitive,
+    val nullableElement: JsonElement?,
+)

--- a/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/type/BuiltInJsonTypesSchemaTest.kt
+++ b/ksp-integration-tests/src/test/kotlin/kotlinx/schema/integration/type/BuiltInJsonTypesSchemaTest.kt
@@ -1,0 +1,37 @@
+package kotlinx.schema.integration.type
+
+import io.kotest.assertions.json.shouldEqualJson
+import kotlin.test.Test
+
+/** KSP end-to-end coverage for #338. */
+class BuiltInJsonTypesSchemaTest {
+    @Test
+    fun `generates schema for built-in kotlinx serialization JSON types`() {
+        val schemaString = BuiltInJsonTypes::class.jsonSchemaString
+
+        // language=json
+        schemaString shouldEqualJson
+            $$"""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "kotlinx.schema.integration.type.BuiltInJsonTypes",
+              "type": "object",
+              "properties": {
+                "element": {},
+                "obj": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "arr": {
+                  "type": "array",
+                  "items": {}
+                },
+                "prim": {},
+                "nullableElement": {}
+              },
+              "required": ["element", "obj", "arr", "prim", "nullableElement"],
+              "additionalProperties": false
+            }
+            """.trimIndent()
+    }
+}


### PR DESCRIPTION
Fixes #338.

kotlinx.serialization's built-in JSON types crashed or mis-generated schemas: `JsonElement` reports `PolymorphicKind.SEALED` without the standard `['type', 'value']` sealed layout, so the serialization introspector threw `Unexpected sealed descriptor structure`; reflection and KSP walked them as sealed hierarchies / structural objects.

All three introspectors (serialization, reflection, KSP) now map them consistently:

| Type | Schema |
|---|---|
| `JsonElement` / `JsonPrimitive` / `JsonNull` | `{}` |
| `JsonObject` | `{"type": "object", "additionalProperties": {}}` |
| `JsonArray` | `{"type": "array", "items": {}}` |

Also hardens `extractSealedSubtypes` to fail with an actionable message (checking both the `type` and `value` wrapper elements) for any other non-standard sealed serializer.

Tests added for all three paths; no public API/ABI change.
