### PR TITLE
fix: add developers information to published POM

### DIFF
--- a/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
@@ -37,6 +37,15 @@ mavenPublishing {
             }
         }
 
+        developers {
+            developer {
+                id = "JetBrains"
+                name = "JetBrains Team"
+                organization = "JetBrains"
+                organizationUrl = "https://www.jetbrains.com"
+            }
+        }
+
         organization {
             name = "JetBrains"
             url = "https://www.jetbrains.com"


### PR DESCRIPTION
## Problem

Publishing `0.6.0` to Maven Central failed validation for every artifact:

```
Deployment failed validation:
  * Developers information is missing
```

The shared `pom {}` in `publishing-convention.gradle.kts` defines `licenses`, `organization`, and `scm`, but no `developers` block, which Maven Central requires.

## Fix

Add a neutral JetBrains `developers` entry to the shared publishing convention, so all module POMs (including the Gradle plugin and its marker publication) include developer information.

## Verification

Published `kotlinx-schema-annotations` and `kotlinx-schema-ksp-gradle-plugin` to the local project repo and confirmed the generated POMs now contain a `<developers>` block.